### PR TITLE
feat(ACCT-001): add invitation table schema

### DIFF
--- a/server/database/migrations/0001_curved_screwball.sql
+++ b/server/database/migrations/0001_curved_screwball.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "invitation" (
+	"id" varchar(26) PRIMARY KEY NOT NULL,
+	"email" varchar(255) NOT NULL,
+	"tenant_id" varchar(26) NOT NULL,
+	"role" varchar(50) NOT NULL,
+	"token" varchar(64) NOT NULL,
+	"status" varchar(20) DEFAULT 'pending' NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"accepted_at" timestamp with time zone,
+	"invited_by" varchar(26) NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "invitation" ADD CONSTRAINT "invitation_tenant_id_tenant_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenant"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "invitation" ADD CONSTRAINT "invitation_invited_by_user_id_fk" FOREIGN KEY ("invited_by") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "invitation_token_idx" ON "invitation" USING btree ("token");--> statement-breakpoint
+CREATE INDEX "invitation_email_idx" ON "invitation" USING btree ("email");--> statement-breakpoint
+CREATE INDEX "invitation_tenant_idx" ON "invitation" USING btree ("tenant_id");

--- a/server/database/schema/index.ts
+++ b/server/database/schema/index.ts
@@ -5,6 +5,7 @@
 export { tenant } from './tenant';
 export { user } from './user';
 export { userTenant } from './user-tenant';
+export { invitation } from './invitation';
 
 // 会場
 export { venue } from './venue';

--- a/server/database/schema/invitation.ts
+++ b/server/database/schema/invitation.ts
@@ -1,0 +1,25 @@
+import { pgTable, varchar, timestamp, uniqueIndex, index } from 'drizzle-orm/pg-core';
+import { user } from './user';
+import { tenant } from './tenant';
+
+// ACCT-001 §6: invitation（招待）
+// 管理者がユーザーをテナントに招待するためのテーブル
+// token は crypto.randomBytes(32).toString('hex') で生成（64文字 hex）
+// 有効期限は作成から7日間
+export const invitation = pgTable('invitation', {
+  id: varchar('id', { length: 26 }).primaryKey(), // ULID
+  email: varchar('email', { length: 255 }).notNull(),
+  tenantId: varchar('tenant_id', { length: 26 }).notNull().references(() => tenant.id),
+  role: varchar('role', { length: 50 }).notNull(),
+  token: varchar('token', { length: 64 }).notNull(),
+  status: varchar('status', { length: 20 }).notNull().default('pending'), // pending / accepted / expired
+  expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+  acceptedAt: timestamp('accepted_at', { withTimezone: true }),
+  invitedBy: varchar('invited_by', { length: 26 }).notNull().references(() => user.id),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+}, (table) => [
+  uniqueIndex('invitation_token_idx').on(table.token),
+  index('invitation_email_idx').on(table.email),
+  index('invitation_tenant_idx').on(table.tenantId),
+]);


### PR DESCRIPTION
## Summary
- invitation テーブルスキーマ追加（招待ベースサインアップ用）
- Drizzle マイグレーション生成

## SSOT参照
- 機能ID: ACCT-001
- 参照セクション: §6
- SSOT: docs/design/features/common/ACCT-001_signup.md

## Test plan
- [ ] `pnpm db:migrate` でマイグレーション成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)