### PR TITLE
feat(AUTH-005): implement idempotent logout with toast

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,5 +1,7 @@
 <template>
-  <NuxtLayout>
-    <NuxtPage />
-  </NuxtLayout>
+  <UApp>
+    <NuxtLayout>
+      <NuxtPage />
+    </NuxtLayout>
+  </UApp>
 </template>

--- a/composables/useAuth.ts
+++ b/composables/useAuth.ts
@@ -250,12 +250,17 @@ export function useAuth() {
   // ログアウト
   // ──────────────────────────────────────
 
-  /** ログアウト（AUTH-005 で拡張予定） */
+  /** ログアウト（AUTH-005 §13.2 準拠: エラーでもログアウトを完了させる） */
   async function logout() {
-    await authClient.signOut();
-    authStore.reset();
-    tenantStore.reset();
-    await router.push('/login');
+    try {
+      await authClient.signOut();
+    } catch {
+      // ネットワークエラー等でも無視 — ローカル状態をクリアしてリダイレクト
+    } finally {
+      authStore.reset();
+      tenantStore.reset();
+      await router.push('/login?reason=logout');
+    }
   }
 
   // ──────────────────────────────────────

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -7,12 +7,26 @@ definePageMeta({
 });
 
 const { handleOAuthCallback } = useAuth();
+const toast = useToast();
 
-// OAuth コールバック処理
+// OAuth コールバック / ログアウトトースト処理
 const route = useRoute();
+const router = useRouter();
 const oauthError = ref('');
 
 onMounted(async () => {
+  // AUTH-005: ログアウト後のトースト表示
+  if (route.query.reason === 'logout') {
+    toast.add({
+      title: 'ログアウトしました',
+      icon: 'i-lucide-log-out',
+      color: 'success',
+    });
+    // URLからクエリパラメータを除去
+    router.replace({ path: '/login', query: {} });
+  }
+
+  // OAuth コールバック処理
   if (route.query.oauth || route.query.error) {
     const result = await handleOAuthCallback();
     if (!result.success && result.error) {


### PR DESCRIPTION
## Summary
- `logout()` はエラーを無視し、常にローカル状態クリア + `/login?reason=logout` にリダイレクト
- ログイン画面で「ログアウトしました」トースト表示
- `app.vue` に `UApp` ラッパー追加（Nuxt UI v3 トースト基盤）
- AUTH-005 §13.2 冪等ログアウト仕様準拠

## Test plan
- [ ] typecheck パス確認済み
- [ ] ブラウザ手動確認: ログアウト→トースト表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)