### PR TITLE
test(slice1): add unit tests for auth validation and constants

### DIFF
--- a/tests/unit/types/auth.constants.test.ts
+++ b/tests/unit/types/auth.constants.test.ts
@@ -1,0 +1,62 @@
+// AUTH-001 / ACCT-001: 定数・型定義のユニットテスト
+
+import { describe, it, expect } from 'vitest';
+import {
+  ROLES,
+  ROLE_REDIRECT_MAP,
+  AUTH_ERROR_MESSAGES,
+  SIGNUP_ERROR_MESSAGES,
+} from '~/types/auth';
+import type { Role } from '~/types/auth';
+
+describe('ROLES', () => {
+  it('10個のロールが定義されている', () => {
+    expect(ROLES).toHaveLength(10);
+  });
+
+  it('全ロールが文字列', () => {
+    for (const role of ROLES) {
+      expect(typeof role).toBe('string');
+    }
+  });
+});
+
+describe('ROLE_REDIRECT_MAP', () => {
+  it('全ロールにリダイレクト先が定義されている', () => {
+    for (const role of ROLES) {
+      expect(ROLE_REDIRECT_MAP[role as Role]).toBeDefined();
+      expect(ROLE_REDIRECT_MAP[role as Role]).toMatch(/^\/app/);
+    }
+  });
+
+  it('system_admin は /app/admin にリダイレクト', () => {
+    expect(ROLE_REDIRECT_MAP.system_admin).toBe('/app/admin');
+  });
+
+  it('participant は /app/events にリダイレクト', () => {
+    expect(ROLE_REDIRECT_MAP.participant).toBe('/app/events');
+  });
+});
+
+describe('AUTH_ERROR_MESSAGES', () => {
+  it('必要なエラーメッセージが全て定義されている', () => {
+    expect(AUTH_ERROR_MESSAGES.INVALID_CREDENTIALS).toBeDefined();
+    expect(AUTH_ERROR_MESSAGES.ACCOUNT_LOCKED).toBeDefined();
+    expect(AUTH_ERROR_MESSAGES.ACCOUNT_DISABLED).toBeDefined();
+    expect(AUTH_ERROR_MESSAGES.NO_TENANT).toBeDefined();
+    expect(AUTH_ERROR_MESSAGES.RATE_LIMITED).toBeDefined();
+    expect(AUTH_ERROR_MESSAGES.OAUTH_CANCELLED).toBeDefined();
+    expect(AUTH_ERROR_MESSAGES.NETWORK_ERROR).toBeDefined();
+    expect(AUTH_ERROR_MESSAGES.SERVER_ERROR).toBeDefined();
+  });
+});
+
+describe('SIGNUP_ERROR_MESSAGES', () => {
+  it('必要なエラーメッセージが全て定義されている', () => {
+    expect(SIGNUP_ERROR_MESSAGES.EMAIL_ALREADY_EXISTS).toBeDefined();
+    expect(SIGNUP_ERROR_MESSAGES.INVITATION_NOT_FOUND).toBeDefined();
+    expect(SIGNUP_ERROR_MESSAGES.INVITATION_EXPIRED).toBeDefined();
+    expect(SIGNUP_ERROR_MESSAGES.INVITATION_ALREADY_USED).toBeDefined();
+    expect(SIGNUP_ERROR_MESSAGES.SIGNUP_FAILED).toBeDefined();
+  });
+});

--- a/tests/unit/types/auth.validation.test.ts
+++ b/tests/unit/types/auth.validation.test.ts
@@ -1,0 +1,198 @@
+// ACCT-001 §9.1: サインアップバリデーション ユニットテスト
+// signupSchema, invitationAcceptSchema の検証
+
+import { describe, it, expect } from 'vitest';
+import { signupSchema, invitationAcceptSchema, loginSchema } from '~/types/auth';
+
+describe('loginSchema', () => {
+  it('有効なデータでバリデーション成功', () => {
+    const result = loginSchema.safeParse({
+      email: 'user@example.com',
+      password: 'password123',
+      rememberMe: false,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('メールアドレスが空の場合エラー', () => {
+    const result = loginSchema.safeParse({
+      email: '',
+      password: 'password123',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('無効なメールアドレスでエラー', () => {
+    const result = loginSchema.safeParse({
+      email: 'invalid-email',
+      password: 'password123',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe('有効なメールアドレスを入力してください');
+    }
+  });
+});
+
+describe('signupSchema', () => {
+  const validData = {
+    name: '山田太郎',
+    email: 'test@example.com',
+    password: 'Valid123!',
+    passwordConfirm: 'Valid123!',
+    termsAccepted: true,
+  };
+
+  it('有効なデータでバリデーション成功', () => {
+    const result = signupSchema.safeParse(validData);
+    expect(result.success).toBe(true);
+  });
+
+  // TC-005: 名前が空
+  it('名前が空の場合エラー', () => {
+    const result = signupSchema.safeParse({ ...validData, name: '' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe('名前を入力してください');
+    }
+  });
+
+  it('名前が100文字を超える場合エラー', () => {
+    const result = signupSchema.safeParse({ ...validData, name: 'a'.repeat(101) });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe('名前は100文字以内で入力してください');
+    }
+  });
+
+  it('名前が100文字ちょうどの場合成功', () => {
+    const result = signupSchema.safeParse({ ...validData, name: 'a'.repeat(100) });
+    expect(result.success).toBe(true);
+  });
+
+  it('メールアドレスが空の場合エラー', () => {
+    const result = signupSchema.safeParse({ ...validData, email: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('無効なメールアドレスでエラー', () => {
+    const result = signupSchema.safeParse({ ...validData, email: 'abc' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe('有効なメールアドレスを入力してください');
+    }
+  });
+
+  // TC-003: パスワードが8文字未満
+  it('パスワードが8文字未満の場合エラー', () => {
+    const result = signupSchema.safeParse({
+      ...validData,
+      password: 'abc',
+      passwordConfirm: 'abc',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe('パスワードは8文字以上で入力してください');
+    }
+  });
+
+  it('パスワードが8文字ちょうどの場合成功', () => {
+    const result = signupSchema.safeParse({
+      ...validData,
+      password: '12345678',
+      passwordConfirm: '12345678',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  // TC-004: パスワード不一致
+  it('パスワードと確認が一致しない場合エラー', () => {
+    const result = signupSchema.safeParse({
+      ...validData,
+      password: 'Valid123!',
+      passwordConfirm: 'Different!',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const confirmError = result.error.issues.find(
+        (i) => i.path.includes('passwordConfirm'),
+      );
+      expect(confirmError?.message).toBe('パスワードが一致しません');
+    }
+  });
+
+  // TC-006: 利用規約未同意
+  it('利用規約未同意の場合エラー', () => {
+    const result = signupSchema.safeParse({
+      ...validData,
+      termsAccepted: false,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const termsError = result.error.issues.find(
+        (i) => i.path.includes('termsAccepted'),
+      );
+      expect(termsError?.message).toBe('利用規約に同意してください');
+    }
+  });
+});
+
+describe('invitationAcceptSchema', () => {
+  const validData = {
+    name: '田中花子',
+    password: 'Secure456!',
+    passwordConfirm: 'Secure456!',
+    termsAccepted: true,
+  };
+
+  it('有効なデータでバリデーション成功', () => {
+    const result = invitationAcceptSchema.safeParse(validData);
+    expect(result.success).toBe(true);
+  });
+
+  it('メールアドレスフィールドがない（招待から取得するため不要）', () => {
+    // invitationAcceptSchema にはemailフィールドが含まれていないことを確認
+    const result = invitationAcceptSchema.safeParse({
+      ...validData,
+      email: 'extra@field.com', // 余分なフィールドは無視される
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('名前が空の場合エラー', () => {
+    const result = invitationAcceptSchema.safeParse({ ...validData, name: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('パスワードが8文字未満の場合エラー', () => {
+    const result = invitationAcceptSchema.safeParse({
+      ...validData,
+      password: 'short',
+      passwordConfirm: 'short',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('パスワード不一致の場合エラー', () => {
+    const result = invitationAcceptSchema.safeParse({
+      ...validData,
+      password: 'Secure456!',
+      passwordConfirm: 'Mismatch!',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const confirmError = result.error.issues.find(
+        (i) => i.path.includes('passwordConfirm'),
+      );
+      expect(confirmError?.message).toBe('パスワードが一致しません');
+    }
+  });
+
+  it('利用規約未同意の場合エラー', () => {
+    const result = invitationAcceptSchema.safeParse({
+      ...validData,
+      termsAccepted: false,
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,13 @@
 import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '~': resolve(__dirname, '.'),
+      '@': resolve(__dirname, '.'),
+    },
+  },
   test: {
     globals: true,
     environment: 'node',


### PR DESCRIPTION
## Summary
- `tests/unit/types/auth.validation.test.ts` — signupSchema/invitationAcceptSchema/loginSchema バリデーション 19テスト
- `tests/unit/types/auth.constants.test.ts` — ROLES/ROLE_REDIRECT_MAP/エラーメッセージ定数 7テスト
- `vitest.config.ts` — ~/@ パスエイリアス追加
- 26テスト全パス

## Test plan
- [x] `pnpm test` — 26 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)