### PR TITLE
feat(LIST-001-003): リスト操作共通パターン

### DIFF
--- a/composables/useList.ts
+++ b/composables/useList.ts
@@ -1,0 +1,312 @@
+// LIST-001-003 フロントエンド リスト操作 Composable
+// 仕様書: docs/design/features/common/LIST-001-003_list-operations.md §9.1
+//
+// URL State Sync 付きのリスト操作（ページネーション・ソート・フィルタ）を提供する。
+//
+// 使用例:
+// ```ts
+// const { data, pagination, loading, filters, updateFilters, changePage, changeSort, clearFilters }
+//   = useList<Event>({
+//     endpoint: '/api/v1/events',
+//     defaultSort: 'start_at',
+//     defaultOrder: 'desc',
+//   })
+// ```
+
+import type { LocationQueryValue } from 'vue-router'
+
+// ──────────────────────────────────────
+// 型定義 (§5.2)
+// ──────────────────────────────────────
+
+export interface ListOptions {
+  /** API エンドポイント (例: '/api/v1/events') */
+  endpoint: string
+  /** デフォルトのソートカラム (未指定時: 'created_at') */
+  defaultSort?: string
+  /** デフォルトのソート順 (未指定時: 'desc') */
+  defaultOrder?: 'asc' | 'desc'
+  /** デフォルトの件数/ページ (未指定時: 20) */
+  defaultPerPage?: number
+}
+
+export interface ListFilters {
+  page: number
+  per_page: number
+  sort: string
+  order: 'asc' | 'desc'
+  q?: string
+  [key: string]: unknown
+}
+
+export interface ListPaginationMeta {
+  total: number
+  page: number
+  per_page: number
+  total_pages: number
+}
+
+// ──────────────────────────────────────
+// Composable 本体
+// ──────────────────────────────────────
+
+/**
+ * リスト操作 Composable
+ *
+ * FR-001: オフセットベースページネーション
+ * FR-003: 単一カラムソート
+ * FR-004-006: フィルタ (複数値, 範囲, フリーテキスト)
+ * FR-007: URL State Sync
+ * FR-008: 空結果表示
+ * FR-009: ローディングスケルトン
+ */
+export function useList<T>(options: ListOptions) {
+  const route = useRoute()
+  const router = useRouter()
+
+  const defaultSort = options.defaultSort || 'created_at'
+  const defaultOrder = options.defaultOrder || 'desc'
+  const defaultPerPage = options.defaultPerPage || 20
+
+  // ──────────────────────────────────────
+  // 状態
+  // ──────────────────────────────────────
+
+  /** フィルタ状態（URLと同期） */
+  const filters = ref<ListFilters>({
+    page: 1,
+    per_page: defaultPerPage,
+    sort: defaultSort,
+    order: defaultOrder,
+    ...parseQueryParams(route.query),
+  }) as Ref<ListFilters>
+
+  /** データ配列 */
+  const data = ref<T[]>([]) as Ref<T[]>
+
+  /** ページネーション情報 */
+  const pagination = ref<ListPaginationMeta>({
+    total: 0,
+    page: 1,
+    per_page: defaultPerPage,
+    total_pages: 0,
+  })
+
+  /** ローディング状態 */
+  const loading = ref(false)
+
+  /** エラー状態 */
+  const error = ref<Error | null>(null)
+
+  /** 結果が 0 件か */
+  const isEmpty = computed(() => !loading.value && data.value.length === 0)
+
+  /** アクティブなフィルタがあるか */
+  const hasActiveFilters = computed(() => {
+    const f = filters.value
+    return !!(
+      f.q
+      || Object.keys(f).some(
+        key =>
+          !['page', 'per_page', 'sort', 'order', 'q'].includes(key)
+          && f[key] !== undefined
+          && f[key] !== '',
+      )
+    )
+  })
+
+  // ──────────────────────────────────────
+  // データ取得
+  // ──────────────────────────────────────
+
+  async function fetchData() {
+    loading.value = true
+    error.value = null
+
+    try {
+      const response = await $fetch<{
+        data: T[]
+        pagination: ListPaginationMeta
+      }>(options.endpoint, {
+        query: cleanQueryParams(filters.value),
+      })
+
+      data.value = response.data
+      pagination.value = response.pagination
+    } catch (e) {
+      error.value = e as Error
+      data.value = []
+      pagination.value = { total: 0, page: 1, per_page: defaultPerPage, total_pages: 0 }
+    } finally {
+      loading.value = false
+    }
+  }
+
+  // ──────────────────────────────────────
+  // フィルタ操作
+  // ──────────────────────────────────────
+
+  /**
+   * フィルタを更新する
+   * フィルタ変更時は page=1 にリセット (仕様: §9.1 updateFilters)
+   */
+  function updateFilters(newFilters: Partial<ListFilters>) {
+    filters.value = {
+      ...filters.value,
+      ...newFilters,
+      page: 1,
+    }
+    syncUrl()
+    fetchData()
+  }
+
+  /**
+   * ページを変更する
+   */
+  function changePage(page: number) {
+    filters.value.page = page
+    syncUrl()
+    fetchData()
+  }
+
+  /**
+   * ソートを変更する
+   * 同じカラムをクリックした場合は asc/desc をトグル
+   * 異なるカラムは desc でリセット
+   */
+  function changeSort(column: string) {
+    if (filters.value.sort === column) {
+      filters.value.order = filters.value.order === 'asc' ? 'desc' : 'asc'
+    } else {
+      filters.value.sort = column
+      filters.value.order = 'desc'
+    }
+    filters.value.page = 1
+    syncUrl()
+    fetchData()
+  }
+
+  /**
+   * 全フィルタをクリアしてデフォルト状態に戻す
+   */
+  function clearFilters() {
+    filters.value = {
+      page: 1,
+      per_page: defaultPerPage,
+      sort: defaultSort,
+      order: defaultOrder,
+    }
+    syncUrl()
+    fetchData()
+  }
+
+  // ──────────────────────────────────────
+  // URL同期 (FR-007)
+  // ──────────────────────────────────────
+
+  function syncUrl() {
+    const cleaned = cleanQueryParams(filters.value)
+    router.push({ query: cleaned })
+  }
+
+  // ──────────────────────────────────────
+  // ライフサイクル
+  // ──────────────────────────────────────
+
+  // 初回ロード
+  onMounted(() => {
+    fetchData()
+  })
+
+  // ブラウザバック/フォワードで URL が変わった時
+  watch(
+    () => route.query,
+    (newQuery) => {
+      const parsed = parseQueryParams(newQuery)
+      const currentClean = cleanQueryParams(filters.value)
+      const newClean = cleanQueryParams({
+        ...filters.value,
+        ...parsed,
+      })
+
+      // 実際に値が変わった場合のみ再フェッチ
+      if (JSON.stringify(currentClean) !== JSON.stringify(newClean)) {
+        filters.value = {
+          page: 1,
+          per_page: defaultPerPage,
+          sort: defaultSort,
+          order: defaultOrder,
+          ...parsed,
+        }
+        fetchData()
+      }
+    },
+  )
+
+  return {
+    data: readonly(data),
+    pagination: readonly(pagination),
+    loading: readonly(loading),
+    error: readonly(error),
+    isEmpty,
+    hasActiveFilters,
+    filters,
+    updateFilters,
+    changePage,
+    changeSort,
+    clearFilters,
+    refresh: fetchData,
+  }
+}
+
+// ──────────────────────────────────────
+// ヘルパー関数
+// ──────────────────────────────────────
+
+/**
+ * URLクエリパラメータを ListFilters にパース
+ */
+function parseQueryParams(
+  query: Record<string, LocationQueryValue | LocationQueryValue[]>,
+): Partial<ListFilters> {
+  const parsed: Partial<ListFilters> = {}
+
+  for (const [key, value] of Object.entries(query)) {
+    if (value === null || value === undefined) continue
+
+    const stringValue = Array.isArray(value) ? value[0] : value
+    if (!stringValue) continue
+
+    // 数値型パラメータ
+    if (key === 'page' || key === 'per_page') {
+      const num = parseInt(stringValue, 10)
+      if (!isNaN(num)) {
+        parsed[key] = num
+      }
+    } else if (key === 'order') {
+      if (stringValue === 'asc' || stringValue === 'desc') {
+        parsed.order = stringValue
+      }
+    } else {
+      parsed[key] = stringValue
+    }
+  }
+
+  return parsed
+}
+
+/**
+ * フィルタを URL クエリパラメータ用にクリーン化
+ * undefined / null / 空文字のパラメータを除外
+ */
+function cleanQueryParams(filters: ListFilters): Record<string, string> {
+  const cleaned: Record<string, string> = {}
+
+  for (const [key, value] of Object.entries(filters)) {
+    if (value !== undefined && value !== null && value !== '') {
+      cleaned[key] = String(value)
+    }
+  }
+
+  return cleaned
+}

--- a/server/utils/list-query.ts
+++ b/server/utils/list-query.ts
@@ -1,0 +1,257 @@
+// LIST-001-003 サーバー側リストクエリヘルパー
+// 仕様書: docs/design/features/common/LIST-001-003_list-operations.md §5, §9.2
+//
+// 各リスト API エンドポイントが共通で使うクエリパラメータのパース・バリデーション・
+// ページネーション計算・ソート適用を行う。
+
+import { z } from 'zod'
+import { asc, desc, sql, and, or, eq, gte, lte, gt, lt, ilike } from 'drizzle-orm'
+import type { PgTable, PgColumn } from 'drizzle-orm/pg-core'
+import type { SQL } from 'drizzle-orm'
+import { db } from './db'
+
+// ──────────────────────────────────────
+// 型定義
+// ──────────────────────────────────────
+
+/** オフセットベースページネーション結果 (§5.2) */
+export interface OffsetPaginationResult<T> {
+  data: T[]
+  pagination: {
+    total: number
+    page: number
+    per_page: number
+    total_pages: number
+  }
+}
+
+/** カーソルベースページネーション結果 (§5.2) */
+export interface CursorPaginationResult<T> {
+  data: T[]
+  next_cursor: string | null
+  has_more: boolean
+}
+
+/** リストクエリオプション */
+export interface ListQueryOptions {
+  /** 許可するソートカラム名 */
+  allowedSortColumns: string[]
+  /** フリーテキスト検索対象カラム（ILIKE 適用） */
+  searchColumns?: PgColumn[]
+  /** デフォルトのソートカラム */
+  defaultSort?: string
+  /** デフォルトのソート順 */
+  defaultOrder?: 'asc' | 'desc'
+}
+
+// ──────────────────────────────────────
+// バリデーションスキーマ (§3.5)
+// ──────────────────────────────────────
+
+/** オフセットベースのクエリパラメータスキーマ */
+export const offsetPaginationSchema = z.object({
+  page: z.coerce.number().int().min(1, 'page must be a positive integer').default(1),
+  per_page: z.coerce.number().int().min(1, 'per_page must be between 1 and 100').max(100, 'per_page must be between 1 and 100').default(20),
+  sort: z.string().optional(),
+  order: z.enum(['asc', 'desc']).default('desc'),
+  q: z.string().max(200).optional(),
+})
+
+/** カーソルベースのクエリパラメータスキーマ */
+export const cursorPaginationSchema = z.object({
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  sort: z.string().optional(),
+  order: z.enum(['asc', 'desc']).default('desc'),
+})
+
+// ──────────────────────────────────────
+// バリデーション関数
+// ──────────────────────────────────────
+
+/**
+ * リストクエリパラメータをバリデーション
+ *
+ * §3.5 境界値 / §3.6 例外レスポンスに基づくエラーハンドリング:
+ * - page < 1 → 400 INVALID_PAGE
+ * - per_page < 1 or > 100 → 400 INVALID_PER_PAGE
+ * - sort が許可リスト外 → 400 INVALID_SORT
+ * - order が asc/desc 以外 → 400 INVALID_ORDER
+ */
+export function validateListQuery(
+  rawQuery: Record<string, unknown>,
+  options: ListQueryOptions,
+): z.infer<typeof offsetPaginationSchema> & Record<string, unknown> {
+  // 基本バリデーション
+  const base = offsetPaginationSchema.safeParse(rawQuery)
+  if (!base.success) {
+    const firstError = base.error.issues[0]
+    const param = firstError?.path[0] as string
+    throw createError({
+      statusCode: 400,
+      statusMessage: `INVALID_${param?.toUpperCase() || 'PARAM'}`,
+      message: firstError?.message || 'バリデーションエラー',
+      data: {
+        code: `INVALID_${param?.toUpperCase() || 'PARAM'}`,
+        details: { parameter: param, constraint: firstError?.message },
+      },
+    })
+  }
+
+  const parsed = base.data
+
+  // ソートカラムバリデーション
+  const sortColumn = parsed.sort || options.defaultSort || 'created_at'
+  if (!options.allowedSortColumns.includes(sortColumn)) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'INVALID_SORT',
+      message: `sort column '${sortColumn}' is not allowed`,
+      data: {
+        code: 'INVALID_SORT',
+        details: {
+          parameter: 'sort',
+          value: sortColumn,
+          allowed: options.allowedSortColumns,
+        },
+      },
+    })
+  }
+
+  // その他のフィルタパラメータをそのまま渡す
+  const filters: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(rawQuery)) {
+    if (!['page', 'per_page', 'sort', 'order', 'q'].includes(key)) {
+      filters[key] = value
+    }
+  }
+
+  return {
+    ...parsed,
+    sort: sortColumn,
+    order: parsed.order || options.defaultOrder || 'desc',
+    ...filters,
+  }
+}
+
+// ──────────────────────────────────────
+// クエリビルダー
+// ──────────────────────────────────────
+
+/**
+ * オフセットベースのリストクエリを実行
+ *
+ * BR-001: テナント分離 (tenant_id 必須)
+ * BR-002: デフォルトソート (created_at desc)
+ * BR-003: per_page 上限 (100)
+ * BR-004: 空検索は全件返却
+ */
+export async function executeListQuery<T>(
+  table: PgTable,
+  tenantId: string,
+  params: z.infer<typeof offsetPaginationSchema> & Record<string, unknown>,
+  options: ListQueryOptions & {
+    /** 追加の WHERE 条件 */
+    additionalConditions?: SQL[]
+  } = { allowedSortColumns: ['created_at'] },
+): Promise<OffsetPaginationResult<T>> {
+  const t = table as unknown as Record<string, PgColumn>
+  const conditions: SQL[] = []
+
+  // テナント分離
+  conditions.push(eq(t.tenantId as PgColumn, tenantId as never))
+
+  // フリーテキスト検索 (BR-004: 空文字はスキップ)
+  if (params.q && params.q.trim() !== '' && options.searchColumns && options.searchColumns.length > 0) {
+    const searchConditions = options.searchColumns.map(col =>
+      ilike(col, `%${params.q}%`),
+    )
+    if (searchConditions.length === 1) {
+      conditions.push(searchConditions[0]!)
+    } else if (searchConditions.length > 1) {
+      const orCondition = or(...searchConditions)
+      if (orCondition) {
+        conditions.push(orCondition)
+      }
+    }
+  }
+
+  // 追加条件
+  if (options.additionalConditions) {
+    conditions.push(...options.additionalConditions)
+  }
+
+  const whereClause = conditions.length > 0 ? and(...conditions) : undefined
+
+  // ソート
+  const sortCol = t[params.sort || 'createdAt']
+  const orderFn = params.order === 'asc' ? asc : desc
+  const orderBy = sortCol ? orderFn(sortCol as PgColumn) : desc(t.createdAt as PgColumn)
+
+  // ページネーション計算
+  const page = params.page || 1
+  const perPage = Math.min(params.per_page || 20, 100)
+  const offset = (page - 1) * perPage
+
+  // データ取得 + カウント並列実行
+  const [data, countResult] = await Promise.all([
+    db.select()
+      .from(table)
+      .where(whereClause)
+      .orderBy(orderBy)
+      .limit(perPage)
+      .offset(offset) as Promise<T[]>,
+    db.select({ count: sql<number>`count(*)::int` })
+      .from(table)
+      .where(whereClause),
+  ])
+
+  const total = countResult[0]?.count ?? 0
+
+  return {
+    data,
+    pagination: {
+      total,
+      page,
+      per_page: perPage,
+      total_pages: Math.ceil(total / perPage),
+    },
+  }
+}
+
+// ──────────────────────────────────────
+// フィルタヘルパー
+// ──────────────────────────────────────
+
+/**
+ * カンマ区切りの値を OR 条件に変換 (FR-004)
+ */
+export function multiValueFilter(column: PgColumn, value: string | undefined): SQL | undefined {
+  if (!value || value.trim() === '') return undefined
+  const values = value.split(',').map(v => v.trim()).filter(Boolean)
+  if (values.length === 0) return undefined
+  if (values.length === 1) return eq(column, values[0] as never)
+  return or(...values.map(v => eq(column, v as never)))
+}
+
+/**
+ * 範囲フィルタを生成 (FR-005)
+ */
+export function rangeFilter(
+  column: PgColumn,
+  params: Record<string, unknown>,
+  paramName: string,
+): SQL[] {
+  const conditions: SQL[] = []
+  const gteValue = params[`${paramName}_gte`]
+  const lteValue = params[`${paramName}_lte`]
+  const gtValue = params[`${paramName}_gt`]
+  const ltValue = params[`${paramName}_lt`]
+
+  if (gteValue) conditions.push(gte(column, new Date(gteValue as string) as never))
+  if (lteValue) conditions.push(lte(column, new Date(lteValue as string) as never))
+  if (gtValue) conditions.push(gt(column, new Date(gtValue as string) as never))
+  if (ltValue) conditions.push(lt(column, new Date(ltValue as string) as never))
+
+  return conditions
+}

--- a/tests/unit/list/list-composable.test.ts
+++ b/tests/unit/list/list-composable.test.ts
@@ -1,0 +1,408 @@
+// LIST-001-003 フロントエンド リスト操作 ユニットテスト
+// 仕様書: docs/design/features/common/LIST-001-003_list-operations.md §9.1
+
+import { describe, it, expect } from 'vitest'
+
+// ──────────────────────────────────────
+// parseQueryParams ロジックテスト (FR-007)
+// ──────────────────────────────────────
+
+type LocationQueryValue = string | null
+
+function parseQueryParams(
+  query: Record<string, LocationQueryValue | LocationQueryValue[]>,
+): Record<string, unknown> {
+  const parsed: Record<string, unknown> = {}
+
+  for (const [key, value] of Object.entries(query)) {
+    if (value === null || value === undefined) continue
+
+    const stringValue = Array.isArray(value) ? value[0] : value
+    if (!stringValue) continue
+
+    if (key === 'page' || key === 'per_page') {
+      const num = parseInt(stringValue, 10)
+      if (!isNaN(num)) {
+        parsed[key] = num
+      }
+    } else if (key === 'order') {
+      if (stringValue === 'asc' || stringValue === 'desc') {
+        parsed.order = stringValue
+      }
+    } else {
+      parsed[key] = stringValue
+    }
+  }
+
+  return parsed
+}
+
+describe('parseQueryParams (FR-007 URL State Sync)', () => {
+  it('空のクエリは空オブジェクトを返す', () => {
+    expect(parseQueryParams({})).toEqual({})
+  })
+
+  it('page を数値にパースする', () => {
+    const result = parseQueryParams({ page: '3' })
+    expect(result.page).toBe(3)
+  })
+
+  it('per_page を数値にパースする', () => {
+    const result = parseQueryParams({ per_page: '50' })
+    expect(result.per_page).toBe(50)
+  })
+
+  it('order=asc はそのまま保持', () => {
+    const result = parseQueryParams({ order: 'asc' })
+    expect(result.order).toBe('asc')
+  })
+
+  it('order=desc はそのまま保持', () => {
+    const result = parseQueryParams({ order: 'desc' })
+    expect(result.order).toBe('desc')
+  })
+
+  it('order=invalid は無視される', () => {
+    const result = parseQueryParams({ order: 'invalid' })
+    expect(result.order).toBeUndefined()
+  })
+
+  it('sort は文字列として保持', () => {
+    const result = parseQueryParams({ sort: 'title' })
+    expect(result.sort).toBe('title')
+  })
+
+  it('q は文字列として保持', () => {
+    const result = parseQueryParams({ q: 'search term' })
+    expect(result.q).toBe('search term')
+  })
+
+  it('null 値は無視される', () => {
+    const result = parseQueryParams({ page: null })
+    expect(result.page).toBeUndefined()
+  })
+
+  it('配列は最初の値を使用', () => {
+    const result = parseQueryParams({ sort: ['title', 'created_at'] })
+    expect(result.sort).toBe('title')
+  })
+
+  it('配列の最初の要素が null の場合は無視', () => {
+    const result = parseQueryParams({ sort: [null, 'title'] })
+    expect(result.sort).toBeUndefined()
+  })
+
+  it('page が数値でない場合は無視', () => {
+    const result = parseQueryParams({ page: 'abc' })
+    expect(result.page).toBeUndefined()
+  })
+
+  it('カスタムフィルタパラメータが保持される', () => {
+    const result = parseQueryParams({ status: 'active', category: 'seminar' })
+    expect(result.status).toBe('active')
+    expect(result.category).toBe('seminar')
+  })
+
+  it('複合クエリが正しくパースされる', () => {
+    const result = parseQueryParams({
+      page: '2',
+      per_page: '10',
+      sort: 'title',
+      order: 'asc',
+      q: 'test',
+      status: 'active',
+    })
+    expect(result.page).toBe(2)
+    expect(result.per_page).toBe(10)
+    expect(result.sort).toBe('title')
+    expect(result.order).toBe('asc')
+    expect(result.q).toBe('test')
+    expect(result.status).toBe('active')
+  })
+})
+
+// ──────────────────────────────────────
+// cleanQueryParams ロジックテスト
+// ──────────────────────────────────────
+
+interface ListFilters {
+  page: number
+  per_page: number
+  sort: string
+  order: 'asc' | 'desc'
+  q?: string
+  [key: string]: unknown
+}
+
+function cleanQueryParams(filters: ListFilters): Record<string, string> {
+  const cleaned: Record<string, string> = {}
+
+  for (const [key, value] of Object.entries(filters)) {
+    if (value !== undefined && value !== null && value !== '') {
+      cleaned[key] = String(value)
+    }
+  }
+
+  return cleaned
+}
+
+describe('cleanQueryParams', () => {
+  it('有効な値をすべて文字列に変換する', () => {
+    const result = cleanQueryParams({
+      page: 1,
+      per_page: 20,
+      sort: 'created_at',
+      order: 'desc',
+    })
+    expect(result.page).toBe('1')
+    expect(result.per_page).toBe('20')
+    expect(result.sort).toBe('created_at')
+    expect(result.order).toBe('desc')
+  })
+
+  it('undefined 値は除外される', () => {
+    const result = cleanQueryParams({
+      page: 1,
+      per_page: 20,
+      sort: 'created_at',
+      order: 'desc',
+      q: undefined,
+    })
+    expect(result.q).toBeUndefined()
+  })
+
+  it('空文字は除外される', () => {
+    const result = cleanQueryParams({
+      page: 1,
+      per_page: 20,
+      sort: 'created_at',
+      order: 'desc',
+      q: '',
+    })
+    expect(result.q).toBeUndefined()
+  })
+
+  it('null 値は除外される', () => {
+    const filters = {
+      page: 1,
+      per_page: 20,
+      sort: 'created_at',
+      order: 'desc' as const,
+      status: null,
+    }
+    const result = cleanQueryParams(filters)
+    expect(result.status).toBeUndefined()
+  })
+
+  it('カスタムフィルタが保持される', () => {
+    const result = cleanQueryParams({
+      page: 1,
+      per_page: 20,
+      sort: 'created_at',
+      order: 'desc',
+      status: 'active',
+    })
+    expect(result.status).toBe('active')
+  })
+})
+
+// ──────────────────────────────────────
+// ソートトグルロジック (FR-003)
+// ──────────────────────────────────────
+
+describe('ソートトグルロジック (FR-003)', () => {
+  function applySort(
+    currentSort: string,
+    currentOrder: 'asc' | 'desc',
+    newColumn: string,
+  ): { sort: string; order: 'asc' | 'desc' } {
+    if (currentSort === newColumn) {
+      return {
+        sort: currentSort,
+        order: currentOrder === 'asc' ? 'desc' : 'asc',
+      }
+    }
+    return { sort: newColumn, order: 'desc' }
+  }
+
+  it('同じカラムで asc→desc にトグルする', () => {
+    const result = applySort('title', 'asc', 'title')
+    expect(result.sort).toBe('title')
+    expect(result.order).toBe('desc')
+  })
+
+  it('同じカラムで desc→asc にトグルする', () => {
+    const result = applySort('title', 'desc', 'title')
+    expect(result.sort).toBe('title')
+    expect(result.order).toBe('asc')
+  })
+
+  it('異なるカラムは desc でリセットする', () => {
+    const result = applySort('title', 'asc', 'created_at')
+    expect(result.sort).toBe('created_at')
+    expect(result.order).toBe('desc')
+  })
+
+  it('新しいカラムは常に desc で始まる', () => {
+    const result = applySort('title', 'desc', 'start_at')
+    expect(result.sort).toBe('start_at')
+    expect(result.order).toBe('desc')
+  })
+})
+
+// ──────────────────────────────────────
+// フィルタリセットロジック
+// ──────────────────────────────────────
+
+describe('フィルタリセットロジック', () => {
+  it('updateFilters はページを1にリセットする', () => {
+    const currentFilters: ListFilters = {
+      page: 5,
+      per_page: 20,
+      sort: 'created_at',
+      order: 'desc',
+      q: 'test',
+    }
+
+    const newFilters = {
+      ...currentFilters,
+      q: 'new search',
+      page: 1, // リセット
+    }
+
+    expect(newFilters.page).toBe(1)
+    expect(newFilters.q).toBe('new search')
+  })
+
+  it('clearFilters はデフォルト状態に戻す', () => {
+    const defaultSort = 'created_at'
+    const defaultOrder = 'desc'
+    const defaultPerPage = 20
+
+    const cleared: ListFilters = {
+      page: 1,
+      per_page: defaultPerPage,
+      sort: defaultSort,
+      order: defaultOrder,
+    }
+
+    expect(cleared.page).toBe(1)
+    expect(cleared.per_page).toBe(20)
+    expect(cleared.sort).toBe('created_at')
+    expect(cleared.order).toBe('desc')
+    expect(cleared.q).toBeUndefined()
+  })
+})
+
+// ──────────────────────────────────────
+// hasActiveFilters ロジック
+// ──────────────────────────────────────
+
+describe('hasActiveFilters ロジック', () => {
+  function checkHasActiveFilters(filters: ListFilters): boolean {
+    return !!(
+      filters.q
+      || Object.keys(filters).some(
+        key =>
+          !['page', 'per_page', 'sort', 'order', 'q'].includes(key)
+          && filters[key] !== undefined
+          && filters[key] !== '',
+      )
+    )
+  }
+
+  it('デフォルト状態はアクティブフィルタなし', () => {
+    expect(checkHasActiveFilters({
+      page: 1,
+      per_page: 20,
+      sort: 'created_at',
+      order: 'desc',
+    })).toBe(false)
+  })
+
+  it('q が設定されている場合はアクティブ', () => {
+    expect(checkHasActiveFilters({
+      page: 1,
+      per_page: 20,
+      sort: 'created_at',
+      order: 'desc',
+      q: 'test',
+    })).toBe(true)
+  })
+
+  it('カスタムフィルタがある場合はアクティブ', () => {
+    expect(checkHasActiveFilters({
+      page: 1,
+      per_page: 20,
+      sort: 'created_at',
+      order: 'desc',
+      status: 'active',
+    })).toBe(true)
+  })
+
+  it('q が空文字の場合はアクティブでない', () => {
+    expect(checkHasActiveFilters({
+      page: 1,
+      per_page: 20,
+      sort: 'created_at',
+      order: 'desc',
+      q: '',
+    })).toBe(false)
+  })
+
+  it('カスタムフィルタが空文字の場合はアクティブでない', () => {
+    expect(checkHasActiveFilters({
+      page: 1,
+      per_page: 20,
+      sort: 'created_at',
+      order: 'desc',
+      status: '',
+    })).toBe(false)
+  })
+
+  it('カスタムフィルタが undefined の場合はアクティブでない', () => {
+    expect(checkHasActiveFilters({
+      page: 1,
+      per_page: 20,
+      sort: 'created_at',
+      order: 'desc',
+      status: undefined,
+    })).toBe(false)
+  })
+
+  it('page/per_page/sort/order の変更はアクティブとみなさない', () => {
+    expect(checkHasActiveFilters({
+      page: 5,
+      per_page: 50,
+      sort: 'title',
+      order: 'asc',
+    })).toBe(false)
+  })
+})
+
+// ──────────────────────────────────────
+// isEmpty ロジック (FR-008)
+// ──────────────────────────────────────
+
+describe('isEmpty ロジック (FR-008)', () => {
+  it('ローディング中は isEmpty=false', () => {
+    const loading = true
+    const dataLength = 0
+    const isEmpty = !loading && dataLength === 0
+    expect(isEmpty).toBe(false)
+  })
+
+  it('データあり → isEmpty=false', () => {
+    const loading = false
+    const dataLength = 5
+    const isEmpty = !loading && dataLength === 0
+    expect(isEmpty).toBe(false)
+  })
+
+  it('ローディング完了 + データなし → isEmpty=true', () => {
+    const loading = false
+    const dataLength = 0
+    const isEmpty = !loading && dataLength === 0
+    expect(isEmpty).toBe(true)
+  })
+})

--- a/tests/unit/list/list-query.test.ts
+++ b/tests/unit/list/list-query.test.ts
@@ -1,0 +1,403 @@
+// LIST-001-003 サーバー側リストクエリ ユニットテスト
+// 仕様書: docs/design/features/common/LIST-001-003_list-operations.md §3.5, §3.6, §9.2
+
+import { describe, it, expect, vi } from 'vitest'
+import { z } from 'zod'
+
+// --------------------------------------------------
+// Nuxt auto-import モック
+// --------------------------------------------------
+vi.stubGlobal('createError', (opts: Record<string, unknown>) => {
+  const err = new Error(opts.message as string) as Error & {
+    statusCode: number
+    statusMessage: string
+    data: unknown
+  }
+  err.statusCode = opts.statusCode as number
+  err.statusMessage = opts.statusMessage as string
+  err.data = opts.data
+  return err
+})
+
+// ──────────────────────────────────────
+// offsetPaginationSchema テスト (§3.5)
+// ──────────────────────────────────────
+
+// スキーマをロジック単位で再現 (Nuxt コンテキスト外)
+const offsetPaginationSchema = z.object({
+  page: z.coerce.number().int().min(1, 'page must be a positive integer').default(1),
+  per_page: z.coerce.number().int().min(1, 'per_page must be between 1 and 100').max(100, 'per_page must be between 1 and 100').default(20),
+  sort: z.string().optional(),
+  order: z.enum(['asc', 'desc']).default('desc'),
+  q: z.string().max(200).optional(),
+})
+
+describe('offsetPaginationSchema バリデーション', () => {
+  it('デフォルト値が正しく設定される', () => {
+    const result = offsetPaginationSchema.parse({})
+    expect(result.page).toBe(1)
+    expect(result.per_page).toBe(20)
+    expect(result.order).toBe('desc')
+    expect(result.sort).toBeUndefined()
+    expect(result.q).toBeUndefined()
+  })
+
+  it('文字列の数値が coerce される', () => {
+    const result = offsetPaginationSchema.parse({ page: '3', per_page: '50' })
+    expect(result.page).toBe(3)
+    expect(result.per_page).toBe(50)
+  })
+
+  it('page=0 はバリデーションエラー', () => {
+    const result = offsetPaginationSchema.safeParse({ page: 0 })
+    expect(result.success).toBe(false)
+  })
+
+  it('page=-1 はバリデーションエラー', () => {
+    const result = offsetPaginationSchema.safeParse({ page: -1 })
+    expect(result.success).toBe(false)
+  })
+
+  it('per_page=0 はバリデーションエラー', () => {
+    const result = offsetPaginationSchema.safeParse({ per_page: 0 })
+    expect(result.success).toBe(false)
+  })
+
+  it('per_page=101 はバリデーションエラー', () => {
+    const result = offsetPaginationSchema.safeParse({ per_page: 101 })
+    expect(result.success).toBe(false)
+  })
+
+  it('per_page=100 は有効', () => {
+    const result = offsetPaginationSchema.parse({ per_page: 100 })
+    expect(result.per_page).toBe(100)
+  })
+
+  it('per_page=1 は有効', () => {
+    const result = offsetPaginationSchema.parse({ per_page: 1 })
+    expect(result.per_page).toBe(1)
+  })
+
+  it('order=asc は有効', () => {
+    const result = offsetPaginationSchema.parse({ order: 'asc' })
+    expect(result.order).toBe('asc')
+  })
+
+  it('order=desc は有効', () => {
+    const result = offsetPaginationSchema.parse({ order: 'desc' })
+    expect(result.order).toBe('desc')
+  })
+
+  it('order=invalid はバリデーションエラー', () => {
+    const result = offsetPaginationSchema.safeParse({ order: 'invalid' })
+    expect(result.success).toBe(false)
+  })
+
+  it('q の最大長は 200 文字', () => {
+    const result = offsetPaginationSchema.parse({ q: 'a'.repeat(200) })
+    expect(result.q).toHaveLength(200)
+  })
+
+  it('q が 201 文字以上はバリデーションエラー', () => {
+    const result = offsetPaginationSchema.safeParse({ q: 'a'.repeat(201) })
+    expect(result.success).toBe(false)
+  })
+
+  it('q=空文字は有効', () => {
+    const result = offsetPaginationSchema.parse({ q: '' })
+    expect(result.q).toBe('')
+  })
+
+  it('page が小数はバリデーションエラー', () => {
+    const result = offsetPaginationSchema.safeParse({ page: 1.5 })
+    expect(result.success).toBe(false)
+  })
+})
+
+// ──────────────────────────────────────
+// validateListQuery ロジックテスト
+// ──────────────────────────────────────
+
+// ロジック再現
+function validateListQuery(
+  rawQuery: Record<string, unknown>,
+  options: { allowedSortColumns: string[]; defaultSort?: string; defaultOrder?: 'asc' | 'desc' },
+) {
+  const base = offsetPaginationSchema.safeParse(rawQuery)
+  if (!base.success) {
+    const firstError = base.error.issues[0]
+    const param = firstError?.path[0] as string
+    throw createError({
+      statusCode: 400,
+      statusMessage: `INVALID_${param?.toUpperCase() || 'PARAM'}`,
+      message: firstError?.message || 'バリデーションエラー',
+      data: {
+        code: `INVALID_${param?.toUpperCase() || 'PARAM'}`,
+        details: { parameter: param, constraint: firstError?.message },
+      },
+    })
+  }
+
+  const parsed = base.data
+  const sortColumn = parsed.sort || options.defaultSort || 'created_at'
+  if (!options.allowedSortColumns.includes(sortColumn)) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'INVALID_SORT',
+      message: `sort column '${sortColumn}' is not allowed`,
+      data: {
+        code: 'INVALID_SORT',
+        details: {
+          parameter: 'sort',
+          value: sortColumn,
+          allowed: options.allowedSortColumns,
+        },
+      },
+    })
+  }
+
+  const filters: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(rawQuery)) {
+    if (!['page', 'per_page', 'sort', 'order', 'q'].includes(key)) {
+      filters[key] = value
+    }
+  }
+
+  return {
+    ...parsed,
+    sort: sortColumn,
+    order: parsed.order || options.defaultOrder || 'desc',
+    ...filters,
+  }
+}
+
+describe('validateListQuery', () => {
+  const options = {
+    allowedSortColumns: ['created_at', 'title', 'start_at'],
+    defaultSort: 'created_at',
+  }
+
+  it('有効なクエリが正しくパースされる', () => {
+    const result = validateListQuery(
+      { page: '2', per_page: '10', sort: 'title', order: 'asc' },
+      options,
+    )
+    expect(result.page).toBe(2)
+    expect(result.per_page).toBe(10)
+    expect(result.sort).toBe('title')
+    expect(result.order).toBe('asc')
+  })
+
+  it('sort 未指定時はデフォルトが使われる', () => {
+    const result = validateListQuery({}, options)
+    expect(result.sort).toBe('created_at')
+  })
+
+  it('sort が許可リスト外の場合は 400 エラー', () => {
+    try {
+      validateListQuery({ sort: 'invalid_column' }, options)
+      expect.unreachable('should throw')
+    } catch (e) {
+      const err = e as Error & { statusCode: number; statusMessage: string; data: { code: string } }
+      expect(err.statusCode).toBe(400)
+      expect(err.statusMessage).toBe('INVALID_SORT')
+      expect(err.data.code).toBe('INVALID_SORT')
+    }
+  })
+
+  it('page=0 の場合は INVALID_PAGE エラー', () => {
+    try {
+      validateListQuery({ page: 0 }, options)
+      expect.unreachable('should throw')
+    } catch (e) {
+      const err = e as Error & { statusCode: number; statusMessage: string }
+      expect(err.statusCode).toBe(400)
+      expect(err.statusMessage).toBe('INVALID_PAGE')
+    }
+  })
+
+  it('per_page=101 の場合は INVALID_PER_PAGE エラー', () => {
+    try {
+      validateListQuery({ per_page: 101 }, options)
+      expect.unreachable('should throw')
+    } catch (e) {
+      const err = e as Error & { statusCode: number; statusMessage: string }
+      expect(err.statusCode).toBe(400)
+      expect(err.statusMessage).toBe('INVALID_PER_PAGE')
+    }
+  })
+
+  it('追加のフィルタパラメータが保持される', () => {
+    const result = validateListQuery(
+      { status: 'active', category: 'seminar' },
+      options,
+    )
+    expect(result.status).toBe('active')
+    expect(result.category).toBe('seminar')
+  })
+
+  it('page / per_page / sort / order / q はフィルタに含まれない', () => {
+    const result = validateListQuery(
+      { page: '1', per_page: '20', sort: 'created_at', order: 'desc', q: 'test', extra: 'value' },
+      options,
+    )
+    // extra のみがフィルタとして含まれるべき
+    expect(result.extra).toBe('value')
+    // 標準パラメータはトップレベルに
+    expect(result.page).toBe(1)
+    expect(result.per_page).toBe(20)
+    expect(result.q).toBe('test')
+  })
+})
+
+// ──────────────────────────────────────
+// ページネーション計算テスト
+// ──────────────────────────────────────
+
+function calculatePagination(total: number, page: number, perPage: number) {
+  return {
+    total,
+    page,
+    per_page: perPage,
+    total_pages: Math.ceil(total / perPage),
+  }
+}
+
+describe('ページネーション計算', () => {
+  it('total=45, page=1, per_page=20 → total_pages=3', () => {
+    const result = calculatePagination(45, 1, 20)
+    expect(result.total_pages).toBe(3)
+  })
+
+  it('total=0 → total_pages=0', () => {
+    const result = calculatePagination(0, 1, 20)
+    expect(result.total_pages).toBe(0)
+  })
+
+  it('total=20, per_page=20 → total_pages=1', () => {
+    const result = calculatePagination(20, 1, 20)
+    expect(result.total_pages).toBe(1)
+  })
+
+  it('total=21, per_page=20 → total_pages=2', () => {
+    const result = calculatePagination(21, 1, 20)
+    expect(result.total_pages).toBe(2)
+  })
+
+  it('total=100, per_page=100 → total_pages=1', () => {
+    const result = calculatePagination(100, 1, 100)
+    expect(result.total_pages).toBe(1)
+  })
+
+  it('total=1, per_page=1 → total_pages=1', () => {
+    const result = calculatePagination(1, 1, 1)
+    expect(result.total_pages).toBe(1)
+  })
+
+  it('オフセット計算: page=3, per_page=20 → offset=40', () => {
+    const page = 3
+    const perPage = 20
+    const offset = (page - 1) * perPage
+    expect(offset).toBe(40)
+  })
+
+  it('オフセット計算: page=1 → offset=0', () => {
+    const page = 1
+    const perPage = 20
+    const offset = (page - 1) * perPage
+    expect(offset).toBe(0)
+  })
+})
+
+// ──────────────────────────────────────
+// フィルタヘルパーロジックテスト (FR-004, FR-005)
+// ──────────────────────────────────────
+
+describe('multiValueFilter ロジック (FR-004)', () => {
+  // ロジックのみテスト（Drizzle なし）
+  function parseMultiValue(value: string | undefined): string[] {
+    if (!value || value.trim() === '') return []
+    return value.split(',').map(v => v.trim()).filter(Boolean)
+  }
+
+  it('単一値を正しくパースする', () => {
+    expect(parseMultiValue('active')).toEqual(['active'])
+  })
+
+  it('カンマ区切りの複数値をパースする', () => {
+    expect(parseMultiValue('active,draft,archived')).toEqual(['active', 'draft', 'archived'])
+  })
+
+  it('空文字は空配列を返す', () => {
+    expect(parseMultiValue('')).toEqual([])
+  })
+
+  it('undefined は空配列を返す', () => {
+    expect(parseMultiValue(undefined)).toEqual([])
+  })
+
+  it('前後のスペースがトリムされる', () => {
+    expect(parseMultiValue(' active , draft ')).toEqual(['active', 'draft'])
+  })
+
+  it('空のカンマ区切り要素は除外される', () => {
+    expect(parseMultiValue('active,,draft')).toEqual(['active', 'draft'])
+  })
+
+  it('カンマのみは空配列を返す', () => {
+    expect(parseMultiValue(',')).toEqual([])
+  })
+})
+
+describe('rangeFilter ロジック (FR-005)', () => {
+  function parseRangeParams(
+    params: Record<string, unknown>,
+    paramName: string,
+  ): { gte?: string; lte?: string; gt?: string; lt?: string } {
+    const result: { gte?: string; lte?: string; gt?: string; lt?: string } = {}
+    const gteValue = params[`${paramName}_gte`]
+    const lteValue = params[`${paramName}_lte`]
+    const gtValue = params[`${paramName}_gt`]
+    const ltValue = params[`${paramName}_lt`]
+
+    if (gteValue) result.gte = String(gteValue)
+    if (lteValue) result.lte = String(lteValue)
+    if (gtValue) result.gt = String(gtValue)
+    if (ltValue) result.lt = String(ltValue)
+
+    return result
+  }
+
+  it('_gte パラメータを認識する', () => {
+    const result = parseRangeParams({ start_at_gte: '2026-01-01' }, 'start_at')
+    expect(result.gte).toBe('2026-01-01')
+  })
+
+  it('_lte パラメータを認識する', () => {
+    const result = parseRangeParams({ start_at_lte: '2026-12-31' }, 'start_at')
+    expect(result.lte).toBe('2026-12-31')
+  })
+
+  it('_gt と _lt の両方を認識する', () => {
+    const result = parseRangeParams(
+      { price_gt: '100', price_lt: '500' },
+      'price',
+    )
+    expect(result.gt).toBe('100')
+    expect(result.lt).toBe('500')
+  })
+
+  it('該当パラメータがない場合は空オブジェクト', () => {
+    const result = parseRangeParams({ other: 'value' }, 'start_at')
+    expect(result).toEqual({})
+  })
+
+  it('_gte と _lte の組み合わせ（範囲指定）', () => {
+    const result = parseRangeParams(
+      { created_at_gte: '2026-01-01', created_at_lte: '2026-01-31' },
+      'created_at',
+    )
+    expect(result.gte).toBe('2026-01-01')
+    expect(result.lte).toBe('2026-01-31')
+  })
+})


### PR DESCRIPTION
## Summary
- `server/utils/list-query.ts`: サーバー側リストクエリヘルパー（Zodバリデーション、オフセットページネーション、テキスト検索、マルチ値/範囲フィルタ）
- `composables/useList.ts`: フロントエンド側リスト操作Composable（URL State Sync、ソートトグル、フィルタ管理）
- `tests/unit/list/`: 77テスト（スキーマバリデーション、クエリパース、ページネーション計算、フィルタロジック、ソートトグル）

## 仕様書
docs/design/features/common/LIST-001-003_list-operations.md

## 対応FR
- FR-001: オフセットベースページネーション
- FR-003: 単一カラムソート（トグル）
- FR-004: 複数値フィルタ（カンマ区切りOR）
- FR-005: 範囲フィルタ（_gte/_lte/_gt/_lt）
- FR-006: フリーテキスト検索（ILIKE）
- FR-007: URL State Sync
- FR-008: 空結果判定

## Test plan
- [x] 77ユニットテスト全パス
- [x] 既存240テスト全パス
- [x] ESLint 新規ファイルにエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)