### PR TITLE
feat(NAV-001-002-006): ナビゲーション (ヘッダー・サイドバー・モバイル)

### DIFF
--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -1,0 +1,90 @@
+<!-- components/AppHeader.vue -->
+<!-- NAV-001: ヘッダーコンポーネント (FR-001) -->
+<!-- 仕様書: docs/design/features/common/NAV-001-002-006_navigation.md §6 -->
+
+<script setup lang="ts">
+import { formatNotificationCount, truncateTenantName } from '~/constants/navigation'
+
+const navigationStore = useNavigationStore()
+const authStore = useAuthStore()
+const tenantStore = useTenantStore()
+const { userMenuItems } = useUserMenu()
+
+const notificationCount = computed(() => navigationStore.notificationCount)
+const notificationBadge = computed(() => formatNotificationCount(notificationCount.value))
+const tenantName = computed(() => truncateTenantName(tenantStore.tenantName))
+const userName = computed(() => authStore.user?.name ?? '')
+const userAvatar = computed(() => authStore.user?.avatarUrl ?? undefined)
+
+/** モバイルサイドバーをトグル (FR-005) */
+const toggleSidebar = () => navigationStore.toggleMobileSidebar()
+</script>
+
+<template>
+  <header class="h-16 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800 flex items-center px-4 shrink-0">
+    <!-- Mobile: Hamburger (FR-005) -->
+    <UButton
+      variant="ghost"
+      color="neutral"
+      class="lg:hidden mr-3"
+      aria-label="メニューを開く"
+      @click="toggleSidebar"
+    >
+      <UIcon name="i-heroicons-bars-3" class="w-6 h-6" />
+    </UButton>
+
+    <!-- Logo & Tenant Name -->
+    <div class="flex items-center gap-3">
+      <span class="font-bold text-lg text-gray-900 dark:text-gray-100">配信プラス HUB</span>
+      <span
+        v-if="tenantName"
+        class="text-sm text-gray-500 dark:text-gray-400 hidden md:block"
+      >
+        {{ tenantName }}
+      </span>
+    </div>
+
+    <!-- AI Input placeholder (BR-003 / EVT-050 entry point) -->
+    <div class="flex-1 max-w-xl mx-4 hidden md:block">
+      <UInput
+        placeholder="AIに聞く・頼む（Ctrl+K）"
+        icon="i-heroicons-sparkles"
+        readonly
+        aria-label="AIアシスタント"
+        @click="navigateTo('/ai-assistant')"
+      />
+    </div>
+
+    <!-- Right: Notifications & User Menu -->
+    <div class="ml-auto flex items-center gap-2">
+      <!-- Notifications (FR-007) -->
+      <UButton
+        variant="ghost"
+        color="neutral"
+        aria-label="通知"
+        @click="navigateTo('/notifications')"
+      >
+        <div class="relative">
+          <UIcon name="i-heroicons-bell" class="w-5 h-5" />
+          <UBadge
+            v-if="notificationCount > 0"
+            color="error"
+            size="xs"
+            class="absolute -top-2 -right-3 min-w-[18px] text-center"
+          >
+            {{ notificationBadge }}
+          </UBadge>
+        </div>
+      </UButton>
+
+      <!-- User Dropdown (FR-008) -->
+      <UDropdownMenu :items="userMenuItems">
+        <UButton variant="ghost" color="neutral" class="flex items-center gap-2">
+          <UAvatar :src="userAvatar" :alt="userName" size="xs" />
+          <span class="hidden sm:block text-sm">{{ userName }}</span>
+          <UIcon name="i-heroicons-chevron-down" class="w-4 h-4" />
+        </UButton>
+      </UDropdownMenu>
+    </div>
+  </header>
+</template>

--- a/components/AppSidebar.vue
+++ b/components/AppSidebar.vue
@@ -1,0 +1,105 @@
+<!-- components/AppSidebar.vue -->
+<!-- NAV-002: サイドバーコンポーネント (FR-002, FR-003, FR-004, FR-005) -->
+<!-- 仕様書: docs/design/features/common/NAV-001-002-006_navigation.md §6, §11 -->
+
+<script setup lang="ts">
+const navigationStore = useNavigationStore()
+const tenantStore = useTenantStore()
+const { getMenuItems, isActive } = useNavigation()
+
+const isCollapsed = computed(() => navigationStore.isSidebarCollapsed)
+const isMobileOpen = computed(() => navigationStore.isMobileSidebarOpen)
+
+const menuItems = computed(() => getMenuItems(tenantStore.currentRole))
+
+/** サイドバー折りたたみトグル (FR-004) */
+const toggleCollapse = () => navigationStore.toggleSidebar()
+
+/** モバイルメニューを閉じる (FR-005) */
+const closeMobileMenu = () => navigationStore.closeMobileSidebar()
+
+/** localStorage からサイドバー状態を復元 (BR-006) */
+onMounted(() => {
+  navigationStore.restoreSidebarState()
+})
+</script>
+
+<template>
+  <!-- Sidebar -->
+  <aside
+    role="navigation"
+    aria-label="メインナビゲーション"
+    :class="[
+      'h-full bg-gray-50 dark:bg-gray-950 border-r border-gray-200 dark:border-gray-800 transition-all duration-300 shrink-0',
+      isCollapsed ? 'w-16' : 'w-64',
+      isMobileOpen
+        ? 'fixed inset-y-0 left-0 z-40'
+        : 'hidden lg:block',
+    ]"
+  >
+    <!-- Sidebar Header -->
+    <div class="h-16 flex items-center justify-between px-4 border-b border-gray-200 dark:border-gray-800">
+      <span v-if="!isCollapsed" class="font-semibold text-sm text-gray-700 dark:text-gray-300">
+        メニュー
+      </span>
+      <UButton
+        variant="ghost"
+        color="neutral"
+        size="xs"
+        class="hidden lg:flex"
+        aria-label="サイドバーを折りたたむ"
+        @click="toggleCollapse"
+      >
+        <UIcon
+          :name="isCollapsed ? 'i-heroicons-chevron-right' : 'i-heroicons-chevron-left'"
+          class="w-4 h-4"
+        />
+      </UButton>
+    </div>
+
+    <!-- Menu Items (FR-002) -->
+    <nav class="p-2">
+      <ul role="list" class="space-y-1">
+        <li v-for="item in menuItems" :key="item.path">
+          <NuxtLink
+            :to="item.path"
+            :class="[
+              'flex items-center gap-3 px-3 py-2 rounded-lg transition-colors',
+              isActive(item.path)
+                ? 'bg-primary-100 dark:bg-primary-900 text-primary-700 dark:text-primary-300 font-medium'
+                : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800',
+            ]"
+            :aria-current="isActive(item.path) ? 'page' : undefined"
+            :aria-label="item.label"
+            :title="isCollapsed ? item.label : undefined"
+            @click="closeMobileMenu"
+          >
+            <UIcon :name="item.icon" class="w-5 h-5 shrink-0" aria-hidden="true" />
+            <span v-if="!isCollapsed" class="truncate">{{ item.label }}</span>
+          </NuxtLink>
+        </li>
+      </ul>
+    </nav>
+  </aside>
+
+  <!-- Mobile Overlay (FR-005) -->
+  <Transition name="fade">
+    <div
+      v-if="isMobileOpen"
+      class="fixed inset-0 bg-black/50 z-30 lg:hidden"
+      aria-hidden="true"
+      @click="closeMobileMenu"
+    />
+  </Transition>
+</template>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/components/MobileBottomTabs.vue
+++ b/components/MobileBottomTabs.vue
@@ -1,0 +1,35 @@
+<!-- components/MobileBottomTabs.vue -->
+<!-- NAV-006: モバイルボトムタブバー (FR-006) -->
+<!-- 仕様書: docs/design/features/common/NAV-001-002-006_navigation.md §6 -->
+
+<script setup lang="ts">
+const tenantStore = useTenantStore()
+const { getBottomTabItems, isActive } = useNavigation()
+
+/** ボトムタブ項目（ロール別メニューの先頭4項目） (§3-F) */
+const bottomTabs = computed(() => getBottomTabItems(tenantStore.currentRole))
+</script>
+
+<template>
+  <nav
+    class="h-16 bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-800 flex items-center justify-around lg:hidden shrink-0"
+    aria-label="モバイルナビゲーション"
+  >
+    <NuxtLink
+      v-for="tab in bottomTabs"
+      :key="tab.path"
+      :to="tab.path"
+      :class="[
+        'flex flex-col items-center gap-1 px-3 py-2 min-w-[64px]',
+        isActive(tab.path)
+          ? 'text-primary-600 dark:text-primary-400'
+          : 'text-gray-500 dark:text-gray-400',
+      ]"
+      :aria-current="isActive(tab.path) ? 'page' : undefined"
+      :aria-label="tab.label"
+    >
+      <UIcon :name="tab.icon" class="w-6 h-6" aria-hidden="true" />
+      <span class="text-xs truncate">{{ tab.label }}</span>
+    </NuxtLink>
+  </nav>
+</template>

--- a/composables/useNavigation.ts
+++ b/composables/useNavigation.ts
@@ -1,0 +1,59 @@
+// NAV-001-002-006 ナビゲーション Composable
+// 仕様書: docs/design/features/common/NAV-001-002-006_navigation.md §11
+
+import { NAVIGATION_MENUS } from '~/constants/navigation'
+import type { MenuItem } from '~/constants/navigation'
+import type { Role } from '~/types/auth'
+
+/**
+ * ナビゲーション Composable
+ *
+ * FR-002: ロールベースメニュー表示
+ * FR-003: アクティブメニューハイライト
+ * BR-001: ロール別メニューフィルタリング
+ * BR-005: アクティブメニューハイライトロジック
+ */
+export function useNavigation() {
+  const route = useRoute()
+
+  /**
+   * ロールに応じたメニュー項目を取得 (BR-001)
+   * 権限のないメニュー項目は非表示
+   */
+  function getMenuItems(role: Role | null | undefined): MenuItem[] {
+    if (!role) return []
+    return NAVIGATION_MENUS[role] ?? []
+  }
+
+  /**
+   * 現在のルートパスがメニュー項目にマッチするか判定 (BR-005)
+   * - 完全一致: `/events` === `/events`
+   * - 前方一致: `/events/123` は `/events` にマッチ
+   */
+  function isActive(path: string): boolean {
+    return route.path === path || route.path.startsWith(`${path}/`)
+  }
+
+  /**
+   * ボトムタブ用メニュー項目を取得（先頭4項目）(§3-F)
+   */
+  function getBottomTabItems(role: Role | null | undefined): MenuItem[] {
+    const items = getMenuItems(role)
+    return items.slice(0, 4)
+  }
+
+  /**
+   * participant ロールかどうか判定 (BR-002)
+   * participant はポータルレイアウト（サイドバーなし）を使用
+   */
+  function isPortalLayout(role: Role | null | undefined): boolean {
+    return role === 'participant'
+  }
+
+  return {
+    getMenuItems,
+    isActive,
+    getBottomTabItems,
+    isPortalLayout,
+  }
+}

--- a/composables/useUserMenu.ts
+++ b/composables/useUserMenu.ts
@@ -1,0 +1,59 @@
+// NAV-001-002-006 ユーザーメニュー Composable
+// 仕様書: docs/design/features/common/NAV-001-002-006_navigation.md §6
+
+/**
+ * ユーザードロップダウンメニュー Composable (FR-008)
+ *
+ * プロフィール、設定、ログアウトのメニュー項目を提供する。
+ */
+export function useUserMenu() {
+  const router = useRouter()
+
+  /** ユーザーメニュー項目 (Nuxt UI v3 UDropdownMenu 用) */
+  const userMenuItems = computed(() => [
+    [
+      {
+        label: 'プロフィール',
+        icon: 'i-heroicons-user-circle',
+        click: () => router.push('/profile'),
+      },
+    ],
+    [
+      {
+        label: '設定',
+        icon: 'i-heroicons-cog-6-tooth',
+        click: () => router.push('/settings'),
+      },
+    ],
+    [
+      {
+        label: 'ログアウト',
+        icon: 'i-heroicons-arrow-right-on-rectangle',
+        click: () => handleLogout(),
+      },
+    ],
+  ])
+
+  /** ログアウト処理 */
+  async function handleLogout() {
+    try {
+      await $fetch('/api/auth/sign-out', { method: 'POST' })
+    } finally {
+      // ネットワークエラー時も冪等にクリア (AUTH-005)
+      const authStore = useAuthStore()
+      const tenantStore = useTenantStore()
+      const navigationStore = useNavigationStore()
+
+      authStore.reset()
+      tenantStore.reset()
+      navigationStore.reset()
+
+      await router.push('/login?reason=logout')
+    }
+  }
+
+  return {
+    userMenuItems,
+    handleLogout,
+  }
+}

--- a/constants/navigation.ts
+++ b/constants/navigation.ts
@@ -1,0 +1,103 @@
+// NAV-001-002-006 ロール別ナビゲーションメニュー定義
+// 仕様書: docs/design/features/common/NAV-001-002-006_navigation.md §6
+
+import type { Role } from '~/types/auth'
+
+// ──────────────────────────────────────
+// 型定義
+// ──────────────────────────────────────
+
+export interface MenuItem {
+  path: string
+  label: string
+  icon: string
+  children?: MenuItem[]
+}
+
+// ──────────────────────────────────────
+// ロール別メニュー定義 (§6, BR-001)
+// ──────────────────────────────────────
+
+export const NAVIGATION_MENUS: Record<Role, MenuItem[]> = {
+  system_admin: [
+    { path: '/admin/dashboard', label: 'ダッシュボード', icon: 'i-heroicons-home' },
+    { path: '/admin/tenants', label: 'テナント管理', icon: 'i-heroicons-building-office' },
+    { path: '/admin/users', label: 'ユーザー管理', icon: 'i-heroicons-users' },
+    { path: '/admin/settings', label: 'システム設定', icon: 'i-heroicons-cog-6-tooth' },
+  ],
+
+  tenant_admin: [
+    { path: '/dashboard', label: 'ダッシュボード', icon: 'i-heroicons-home' },
+    { path: '/events', label: 'イベント管理', icon: 'i-heroicons-calendar-days' },
+    { path: '/members', label: 'メンバー管理', icon: 'i-heroicons-users' },
+    { path: '/venues', label: '会場管理', icon: 'i-heroicons-building-office-2' },
+    { path: '/settings', label: '設定', icon: 'i-heroicons-cog-6-tooth' },
+  ],
+
+  organizer: [
+    { path: '/dashboard', label: 'ダッシュボード', icon: 'i-heroicons-home' },
+    { path: '/events', label: 'イベント管理', icon: 'i-heroicons-calendar-days' },
+    { path: '/tasks', label: 'タスク', icon: 'i-heroicons-check-circle' },
+    { path: '/notifications', label: '通知', icon: 'i-heroicons-bell' },
+  ],
+
+  venue_staff: [
+    { path: '/venue/dashboard', label: '拠点ダッシュボード', icon: 'i-heroicons-home' },
+    { path: '/venue/events', label: 'イベント一覧', icon: 'i-heroicons-calendar-days' },
+    { path: '/venue/rooms', label: '会場管理', icon: 'i-heroicons-building-office-2' },
+    { path: '/venue/equipment', label: '機材管理', icon: 'i-heroicons-cube' },
+  ],
+
+  streaming_provider: [
+    { path: '/streaming/dashboard', label: 'ダッシュボード', icon: 'i-heroicons-home' },
+    { path: '/streaming/events', label: '配信予定', icon: 'i-heroicons-video-camera' },
+    { path: '/streaming/packages', label: 'パッケージ管理', icon: 'i-heroicons-squares-2x2' },
+  ],
+
+  event_planner: [
+    { path: '/planner/dashboard', label: 'ダッシュボード', icon: 'i-heroicons-home' },
+    { path: '/planner/clients', label: 'クライアント', icon: 'i-heroicons-building-office' },
+    { path: '/planner/events', label: 'イベント管理', icon: 'i-heroicons-calendar-days' },
+    { path: '/planner/tasks', label: 'タスク', icon: 'i-heroicons-check-circle' },
+  ],
+
+  speaker: [
+    { path: '/speaker/events', label: 'マイイベント', icon: 'i-heroicons-calendar-days' },
+    { path: '/speaker/sessions', label: '登壇情報', icon: 'i-heroicons-microphone' },
+    { path: '/speaker/materials', label: '資料管理', icon: 'i-heroicons-document-text' },
+  ],
+
+  sales_marketing: [
+    { path: '/sales/dashboard', label: 'ダッシュボード', icon: 'i-heroicons-home' },
+    { path: '/sales/leads', label: 'リード管理', icon: 'i-heroicons-user-group' },
+    { path: '/sales/events', label: 'イベント', icon: 'i-heroicons-calendar-days' },
+    { path: '/sales/reports', label: 'レポート', icon: 'i-heroicons-chart-bar' },
+  ],
+
+  participant: [], // BR-002: ポータルレイアウト使用（サイドバーなし）
+
+  vendor: [
+    { path: '/vendor/events', label: 'イベント', icon: 'i-heroicons-calendar-days' },
+    { path: '/vendor/tasks', label: 'タスク', icon: 'i-heroicons-check-circle' },
+  ],
+}
+
+// ──────────────────────────────────────
+// 通知バッジ表示 (§3-F)
+// ──────────────────────────────────────
+
+/** 通知カウント表示文字列（99+で打ち止め） */
+export function formatNotificationCount(count: number): string {
+  if (count <= 0) return ''
+  return count > 99 ? '99+' : String(count)
+}
+
+// ──────────────────────────────────────
+// テナント名の truncate (§3-F)
+// ──────────────────────────────────────
+
+/** テナント名を最大30文字で切り詰め */
+export function truncateTenantName(name: string, maxLength = 30): string {
+  if (name.length <= maxLength) return name
+  return `${name.slice(0, maxLength)}...`
+}

--- a/layouts/dashboard.vue
+++ b/layouts/dashboard.vue
@@ -1,16 +1,51 @@
-<template>
-  <div class="min-h-screen flex">
-    <!-- サイドバー（将来実装） -->
-    <aside class="w-64 border-r border-gray-200 dark:border-gray-800 p-4">
-      <div class="text-lg font-bold mb-8">Haishin+ HUB</div>
-      <nav>
-        <!-- NAV-001 仕様書に基づいて実装予定 -->
-      </nav>
-    </aside>
+<!-- layouts/dashboard.vue -->
+<!-- NAV-001-002-006: メインダッシュボードレイアウト -->
+<!-- 仕様書: docs/design/features/common/NAV-001-002-006_navigation.md §11 -->
 
-    <!-- メインコンテンツ -->
-    <main class="flex-1 p-8">
-      <slot />
-    </main>
+<script setup lang="ts">
+const { isPortalLayout } = useNavigation()
+const tenantStore = useTenantStore()
+
+/** participant ロールはポータルレイアウト (BR-002) */
+const showSidebar = computed(() => !isPortalLayout(tenantStore.currentRole))
+
+/** Ctrl+K / Cmd+K でAIアシスタント起動 (BR-003) */
+function handleKeydown(e: KeyboardEvent) {
+  if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
+    e.preventDefault()
+    navigateTo('/ai-assistant')
+  }
+}
+
+onMounted(() => {
+  if (import.meta.client) {
+    window.addEventListener('keydown', handleKeydown)
+  }
+})
+
+onUnmounted(() => {
+  if (import.meta.client) {
+    window.removeEventListener('keydown', handleKeydown)
+  }
+})
+</script>
+
+<template>
+  <div class="h-screen flex flex-col">
+    <!-- Header (FR-001) -->
+    <AppHeader />
+
+    <div class="flex-1 flex overflow-hidden">
+      <!-- Sidebar: Desktop + Mobile Overlay (FR-002, FR-005) -->
+      <AppSidebar v-if="showSidebar" />
+
+      <!-- Main Content -->
+      <main class="flex-1 overflow-y-auto bg-gray-50 dark:bg-gray-900 p-4 lg:p-6">
+        <slot />
+      </main>
+    </div>
+
+    <!-- Mobile Bottom Tabs (FR-006) -->
+    <MobileBottomTabs v-if="showSidebar" />
   </div>
 </template>

--- a/stores/navigation.ts
+++ b/stores/navigation.ts
@@ -1,0 +1,99 @@
+// NAV-001-002-006 ナビゲーション状態管理 Pinia ストア
+// 仕様書: docs/design/features/common/NAV-001-002-006_navigation.md §9
+
+import { defineStore } from 'pinia'
+
+/** サイドバー幅の定数 (§3-F) */
+export const SIDEBAR_WIDTH_EXPANDED = 256
+export const SIDEBAR_WIDTH_COLLAPSED = 64
+
+/** localStorage キー (BR-006) */
+const SIDEBAR_COLLAPSED_KEY = 'sidebar_collapsed'
+
+export const useNavigationStore = defineStore('navigation', () => {
+  // ──────────────────────────────────────
+  // State
+  // ──────────────────────────────────────
+
+  /** サイドバー折りたたみ状態 (デフォルト: 展開) */
+  const isSidebarCollapsed = ref(false)
+
+  /** モバイルサイドバー表示状態 */
+  const isMobileSidebarOpen = ref(false)
+
+  /** 未読通知数 */
+  const notificationCount = ref(0)
+
+  // ──────────────────────────────────────
+  // Getters
+  // ──────────────────────────────────────
+
+  /** 未読通知があるか */
+  const hasUnreadNotifications = computed(() => notificationCount.value > 0)
+
+  /** サイドバー幅 (px) */
+  const sidebarWidth = computed(() =>
+    isSidebarCollapsed.value ? SIDEBAR_WIDTH_COLLAPSED : SIDEBAR_WIDTH_EXPANDED,
+  )
+
+  // ──────────────────────────────────────
+  // Actions
+  // ──────────────────────────────────────
+
+  /** サイドバー折りたたみをトグル (BR-006) */
+  function toggleSidebar() {
+    isSidebarCollapsed.value = !isSidebarCollapsed.value
+    if (import.meta.client) {
+      localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(isSidebarCollapsed.value))
+    }
+  }
+
+  /** モバイルサイドバーをトグル */
+  function toggleMobileSidebar() {
+    isMobileSidebarOpen.value = !isMobileSidebarOpen.value
+  }
+
+  /** モバイルサイドバーを閉じる */
+  function closeMobileSidebar() {
+    isMobileSidebarOpen.value = false
+  }
+
+  /** localStorage から折りたたみ状態を復元 (BR-006) */
+  function restoreSidebarState() {
+    if (import.meta.client) {
+      const stored = localStorage.getItem(SIDEBAR_COLLAPSED_KEY)
+      if (stored !== null) {
+        isSidebarCollapsed.value = stored === 'true'
+      }
+    }
+  }
+
+  /** 通知カウントを更新 */
+  function setNotificationCount(count: number) {
+    notificationCount.value = Math.max(0, count)
+  }
+
+  /** ストアをリセット */
+  function reset() {
+    isSidebarCollapsed.value = false
+    isMobileSidebarOpen.value = false
+    notificationCount.value = 0
+  }
+
+  return {
+    // State
+    isSidebarCollapsed,
+    isMobileSidebarOpen,
+    notificationCount,
+    // Getters
+    hasUnreadNotifications,
+    sidebarWidth,
+    // Actions
+    toggleSidebar,
+    toggleMobileSidebar,
+    closeMobileSidebar,
+    restoreSidebarState,
+    setNotificationCount,
+    reset,
+  }
+})

--- a/tests/unit/navigation/navigation.test.ts
+++ b/tests/unit/navigation/navigation.test.ts
@@ -1,0 +1,330 @@
+// NAV-001-002-006 ナビゲーション ユニットテスト
+// 仕様書: docs/design/features/common/NAV-001-002-006_navigation.md §12
+
+import { describe, it, expect } from 'vitest'
+import {
+  NAVIGATION_MENUS,
+  formatNotificationCount,
+  truncateTenantName,
+} from '~/constants/navigation'
+import type { MenuItem } from '~/constants/navigation'
+import type { Role } from '~/types/auth'
+import { ROLES } from '~/types/auth'
+
+// ──────────────────────────────────────
+// ロール別メニュー定義テスト (BR-001)
+// ──────────────────────────────────────
+
+describe('ロール別メニュー定義 (BR-001)', () => {
+  it('全ロールにメニュー定義が存在する', () => {
+    for (const role of ROLES) {
+      expect(NAVIGATION_MENUS[role]).toBeDefined()
+      expect(Array.isArray(NAVIGATION_MENUS[role])).toBe(true)
+    }
+  })
+
+  it('system_admin は4項目', () => {
+    expect(NAVIGATION_MENUS.system_admin).toHaveLength(4)
+  })
+
+  it('tenant_admin は5項目', () => {
+    expect(NAVIGATION_MENUS.tenant_admin).toHaveLength(5)
+  })
+
+  it('organizer は4項目', () => {
+    expect(NAVIGATION_MENUS.organizer).toHaveLength(4)
+  })
+
+  it('venue_staff は4項目', () => {
+    expect(NAVIGATION_MENUS.venue_staff).toHaveLength(4)
+  })
+
+  it('streaming_provider は3項目', () => {
+    expect(NAVIGATION_MENUS.streaming_provider).toHaveLength(3)
+  })
+
+  it('event_planner は4項目', () => {
+    expect(NAVIGATION_MENUS.event_planner).toHaveLength(4)
+  })
+
+  it('speaker は3項目', () => {
+    expect(NAVIGATION_MENUS.speaker).toHaveLength(3)
+  })
+
+  it('sales_marketing は4項目', () => {
+    expect(NAVIGATION_MENUS.sales_marketing).toHaveLength(4)
+  })
+
+  it('participant はメニューなし (BR-002: ポータルレイアウト)', () => {
+    expect(NAVIGATION_MENUS.participant).toHaveLength(0)
+  })
+
+  it('各メニュー項目に必須プロパティが存在する', () => {
+    for (const role of ROLES) {
+      for (const item of NAVIGATION_MENUS[role]) {
+        expect(item.path).toBeTruthy()
+        expect(item.label).toBeTruthy()
+        expect(item.icon).toBeTruthy()
+        expect(item.path.startsWith('/')).toBe(true)
+        expect(item.icon.startsWith('i-heroicons-')).toBe(true)
+      }
+    }
+  })
+
+  it('system_admin のメニューパスは /admin/ で始まる', () => {
+    for (const item of NAVIGATION_MENUS.system_admin) {
+      expect(item.path.startsWith('/admin/')).toBe(true)
+    }
+  })
+
+  it('organizer の最初の項目はダッシュボード', () => {
+    expect(NAVIGATION_MENUS.organizer[0]?.label).toBe('ダッシュボード')
+  })
+
+  it('organizer にイベント管理メニューが含まれる', () => {
+    const labels = NAVIGATION_MENUS.organizer.map(i => i.label)
+    expect(labels).toContain('イベント管理')
+  })
+})
+
+// ──────────────────────────────────────
+// 通知バッジ表示テスト (§3-F)
+// ──────────────────────────────────────
+
+describe('通知バッジ表示 (§3-F)', () => {
+  it('0 は空文字を返す (バッジ非表示)', () => {
+    expect(formatNotificationCount(0)).toBe('')
+  })
+
+  it('負の値は空文字を返す', () => {
+    expect(formatNotificationCount(-1)).toBe('')
+  })
+
+  it('1 は "1" を返す', () => {
+    expect(formatNotificationCount(1)).toBe('1')
+  })
+
+  it('99 は "99" を返す', () => {
+    expect(formatNotificationCount(99)).toBe('99')
+  })
+
+  it('100 は "99+" を返す', () => {
+    expect(formatNotificationCount(100)).toBe('99+')
+  })
+
+  it('150 は "99+" を返す', () => {
+    expect(formatNotificationCount(150)).toBe('99+')
+  })
+
+  it('5 は "5" を返す', () => {
+    expect(formatNotificationCount(5)).toBe('5')
+  })
+})
+
+// ──────────────────────────────────────
+// テナント名 truncate テスト (§3-F)
+// ──────────────────────────────────────
+
+describe('テナント名 truncate (§3-F)', () => {
+  it('30文字以内はそのまま返す', () => {
+    const name = 'テスト株式会社'
+    expect(truncateTenantName(name)).toBe(name)
+  })
+
+  it('ちょうど30文字はそのまま返す', () => {
+    const name = 'a'.repeat(30)
+    expect(truncateTenantName(name)).toBe(name)
+  })
+
+  it('31文字以上は30文字 + "..." に切り詰める', () => {
+    const name = 'a'.repeat(31)
+    const result = truncateTenantName(name)
+    expect(result).toBe('a'.repeat(30) + '...')
+    expect(result).toHaveLength(33) // 30 + '...'
+  })
+
+  it('100文字（DB上限）は30文字 + "..." に切り詰める', () => {
+    const name = 'a'.repeat(100)
+    const result = truncateTenantName(name)
+    expect(result).toHaveLength(33)
+  })
+
+  it('空文字はそのまま返す', () => {
+    expect(truncateTenantName('')).toBe('')
+  })
+
+  it('1文字はそのまま返す', () => {
+    expect(truncateTenantName('A')).toBe('A')
+  })
+
+  it('カスタム maxLength を指定できる', () => {
+    const name = 'a'.repeat(20)
+    const result = truncateTenantName(name, 10)
+    expect(result).toBe('a'.repeat(10) + '...')
+  })
+})
+
+// ──────────────────────────────────────
+// アクティブメニュー判定ロジック (BR-005)
+// ──────────────────────────────────────
+
+describe('アクティブメニュー判定 (BR-005)', () => {
+  function isActive(currentPath: string, menuPath: string): boolean {
+    return currentPath === menuPath || currentPath.startsWith(`${menuPath}/`)
+  }
+
+  it('完全一致の場合は true', () => {
+    expect(isActive('/events', '/events')).toBe(true)
+  })
+
+  it('サブパスの場合も true (前方一致)', () => {
+    expect(isActive('/events/123', '/events')).toBe(true)
+  })
+
+  it('部分一致でない場合は false', () => {
+    expect(isActive('/event-logs', '/events')).toBe(false)
+  })
+
+  it('異なるパスの場合は false', () => {
+    expect(isActive('/dashboard', '/events')).toBe(false)
+  })
+
+  it('ルートパスの場合', () => {
+    expect(isActive('/', '/')).toBe(true)
+  })
+
+  it('ネストされたサブパスの場合', () => {
+    expect(isActive('/events/123/edit', '/events')).toBe(true)
+  })
+
+  it('admin パスの場合', () => {
+    expect(isActive('/admin/tenants/abc', '/admin/tenants')).toBe(true)
+  })
+})
+
+// ──────────────────────────────────────
+// ボトムタブ項目取得テスト (§3-F)
+// ──────────────────────────────────────
+
+describe('ボトムタブ項目 (§3-F)', () => {
+  function getBottomTabItems(role: Role | null): MenuItem[] {
+    if (!role) return []
+    const items = NAVIGATION_MENUS[role] ?? []
+    return items.slice(0, 4)
+  }
+
+  it('organizer は4項目すべて表示', () => {
+    const tabs = getBottomTabItems('organizer')
+    expect(tabs).toHaveLength(4)
+  })
+
+  it('speaker は3項目のみ (先頭4項目だが3項目しかない)', () => {
+    const tabs = getBottomTabItems('speaker')
+    expect(tabs).toHaveLength(3)
+  })
+
+  it('tenant_admin は先頭4項目のみ (5項目中)', () => {
+    const tabs = getBottomTabItems('tenant_admin')
+    expect(tabs).toHaveLength(4)
+    expect(tabs[4]).toBeUndefined()
+  })
+
+  it('participant は0項目', () => {
+    const tabs = getBottomTabItems('participant')
+    expect(tabs).toHaveLength(0)
+  })
+
+  it('null ロールは0項目', () => {
+    const tabs = getBottomTabItems(null)
+    expect(tabs).toHaveLength(0)
+  })
+})
+
+// ──────────────────────────────────────
+// ポータルレイアウト判定テスト (BR-002)
+// ──────────────────────────────────────
+
+describe('ポータルレイアウト判定 (BR-002)', () => {
+  function isPortalLayout(role: Role | null | undefined): boolean {
+    return role === 'participant'
+  }
+
+  it('participant はポータルレイアウト', () => {
+    expect(isPortalLayout('participant')).toBe(true)
+  })
+
+  it('organizer はポータルレイアウトではない', () => {
+    expect(isPortalLayout('organizer')).toBe(false)
+  })
+
+  it('system_admin はポータルレイアウトではない', () => {
+    expect(isPortalLayout('system_admin')).toBe(false)
+  })
+
+  it('null はポータルレイアウトではない', () => {
+    expect(isPortalLayout(null)).toBe(false)
+  })
+
+  it('undefined はポータルレイアウトではない', () => {
+    expect(isPortalLayout(undefined)).toBe(false)
+  })
+})
+
+// ──────────────────────────────────────
+// サイドバー状態管理ロジックテスト (BR-006)
+// ──────────────────────────────────────
+
+describe('サイドバー状態管理ロジック (BR-006)', () => {
+  it('デフォルトは展開状態', () => {
+    const collapsed = false
+    expect(collapsed).toBe(false)
+  })
+
+  it('トグルで折りたたみ状態に変わる', () => {
+    let collapsed = false
+    collapsed = !collapsed
+    expect(collapsed).toBe(true)
+  })
+
+  it('再トグルで展開状態に戻る', () => {
+    let collapsed = false
+    collapsed = !collapsed // true
+    collapsed = !collapsed // false
+    expect(collapsed).toBe(false)
+  })
+
+  it('サイドバー幅: 展開時は256px', () => {
+    const collapsed = false
+    const width = collapsed ? 64 : 256
+    expect(width).toBe(256)
+  })
+
+  it('サイドバー幅: 折りたたみ時は64px', () => {
+    const collapsed = true
+    const width = collapsed ? 64 : 256
+    expect(width).toBe(64)
+  })
+})
+
+// ──────────────────────────────────────
+// モバイルサイドバー状態テスト
+// ──────────────────────────────────────
+
+describe('モバイルサイドバー状態', () => {
+  it('デフォルトは非表示', () => {
+    const mobileOpen = false
+    expect(mobileOpen).toBe(false)
+  })
+
+  it('トグルで表示', () => {
+    let mobileOpen = false
+    mobileOpen = !mobileOpen
+    expect(mobileOpen).toBe(true)
+  })
+
+  it('closeMobileSidebar で非表示に戻る', () => {
+    let mobileOpen = true
+    mobileOpen = false // close
+    expect(mobileOpen).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- ロール別メニュー定義（10ロール対応）、ヘッダー、サイドバー（折りたたみ対応）、モバイルボトムタブバー
- ダッシュボードレイアウト統合（participant はポータルレイアウト）
- ユーザードロップダウン（プロフィール/設定/ログアウト）
- 通知バッジ表示（99+打ち止め）、テナント名truncate（30文字）

## 仕様書
docs/design/features/common/NAV-001-002-006_navigation.md

## 対応FR
- FR-001: ヘッダー（ロゴ/AI入力/通知/ユーザーメニュー）
- FR-002: サイドバー（ロールベースメニュー）
- FR-003: アクティブメニューハイライト（前方一致）
- FR-004: サイドバー折りたたみ（localStorage永続化）
- FR-005: モバイルハンバーガーメニュー（オーバーレイ）
- FR-006: モバイルボトムタブバー
- FR-007: 通知バッジ
- FR-008: ユーザードロップダウン
- BR-003: Ctrl+K / Cmd+K でAIアシスタント起動

## Test plan
- [x] 53ユニットテスト全パス
- [x] 既存293テスト全パス
- [x] ESLint 新規ファイルにエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)