### PR TITLE
feat(EVT-010-014): タスク・スケジュール管理

### DIFF
--- a/composables/useTasks.ts
+++ b/composables/useTasks.ts
@@ -1,0 +1,267 @@
+// EVT-010-014: タスク・スケジュール管理 Composable
+// 仕様書: docs/design/features/project/EVT-010-014_master-schedule.md
+
+// ──────────────────────────────────────
+// 型定義
+// ──────────────────────────────────────
+
+export type TaskStatus = 'pending' | 'in_progress' | 'completed' | 'skipped'
+export type TaskPriority = 'high' | 'medium' | 'low'
+
+export interface TaskData {
+  id: string
+  event_id: string
+  tenant_id: string
+  title: string
+  description: string | null
+  assigned_role: string | null
+  assigned_user_id: string | null
+  status: TaskStatus
+  priority: TaskPriority
+  relative_day: number | null
+  due_at: string | null
+  completed_at: string | null
+  sort_order: number
+  template_id: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface TaskSummary {
+  total: number
+  pending: number
+  inProgress: number
+  completed: number
+  skipped: number
+  overdue: number
+}
+
+export interface CreateTaskPayload {
+  title: string
+  description?: string
+  assigned_role?: string
+  assigned_user_id?: string
+  priority?: TaskPriority
+  relative_day?: number
+  due_at?: string
+  sort_order?: number
+}
+
+export interface TaskTemplateData {
+  id: string
+  tenant_id: string | null
+  event_type: string
+  title: string
+  description: string | null
+  assigned_role: string
+  relative_day: number
+  priority: TaskPriority
+  sort_order: number
+  is_active: boolean
+  created_at: string
+  updated_at: string
+}
+
+// ──────────────────────────────────────
+// ラベル定数
+// ──────────────────────────────────────
+
+export const TASK_STATUS_LABELS: Record<TaskStatus, string> = {
+  pending: '未着手',
+  in_progress: '進行中',
+  completed: '完了',
+  skipped: 'スキップ',
+}
+
+export const TASK_STATUS_COLORS: Record<TaskStatus, string> = {
+  pending: 'neutral',
+  in_progress: 'info',
+  completed: 'success',
+  skipped: 'warning',
+}
+
+export const TASK_PRIORITY_LABELS: Record<TaskPriority, string> = {
+  high: '高',
+  medium: '中',
+  low: '低',
+}
+
+export const TASK_PRIORITY_COLORS: Record<TaskPriority, string> = {
+  high: 'error',
+  medium: 'warning',
+  low: 'neutral',
+}
+
+export const TASK_ROLE_LABELS: Record<string, string> = {
+  organizer: '主催者',
+  venue: '会場担当',
+  streaming: '配信担当',
+  event_planner: '企画代行',
+  speaker: '登壇者',
+  vendor: '業者',
+}
+
+// ──────────────────────────────────────
+// ヘルパー関数
+// ──────────────────────────────────────
+
+export function getTaskStatusLabel(status: TaskStatus): string {
+  return TASK_STATUS_LABELS[status] ?? status
+}
+
+export function getTaskStatusColor(status: TaskStatus): string {
+  return TASK_STATUS_COLORS[status] ?? 'neutral'
+}
+
+export function getTaskPriorityLabel(priority: TaskPriority): string {
+  return TASK_PRIORITY_LABELS[priority] ?? priority
+}
+
+export function getTaskPriorityColor(priority: TaskPriority): string {
+  return TASK_PRIORITY_COLORS[priority] ?? 'neutral'
+}
+
+export function getTaskRoleLabel(role: string | null): string {
+  if (!role) return '未割当'
+  return TASK_ROLE_LABELS[role] ?? role
+}
+
+/** 進捗率を計算（0-100） */
+export function calculateProgress(summary: TaskSummary): number {
+  if (summary.total === 0) return 0
+  return Math.round(((summary.completed + summary.skipped) / summary.total) * 100)
+}
+
+/** 相対日を表示用文字列に変換 */
+export function formatRelativeDay(day: number | null): string {
+  if (day === null) return '手動設定'
+  if (day === 0) return 'D-Day'
+  if (day < 0) return `D${day}`
+  return `D+${day}`
+}
+
+// ──────────────────────────────────────
+// useTasks Composable
+// ──────────────────────────────────────
+
+export function useTasks(eventId: string) {
+  const tasks = ref<TaskData[]>([])
+  const summary = ref<TaskSummary>({ total: 0, pending: 0, inProgress: 0, completed: 0, skipped: 0, overdue: 0 })
+  const isLoading = ref(false)
+  const error = ref<string | null>(null)
+
+  async function fetchTasks(filters?: { role?: string; status?: string }) {
+    isLoading.value = true
+    error.value = null
+    try {
+      const res = await $fetch<{ tasks: TaskData[]; summary: TaskSummary }>(`/api/v1/events/${eventId}/tasks`, {
+        query: filters,
+      })
+      tasks.value = res.tasks
+      summary.value = res.summary
+    } catch (err: unknown) {
+      error.value = (err as { data?: { message?: string } })?.data?.message ?? 'タスクの取得に失敗しました'
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  async function createTask(payload: CreateTaskPayload): Promise<TaskData | null> {
+    isLoading.value = true
+    error.value = null
+    try {
+      const res = await $fetch<{ task: TaskData }>(`/api/v1/events/${eventId}/tasks`, {
+        method: 'POST',
+        body: payload,
+      })
+      await fetchTasks()
+      return res.task
+    } catch (err: unknown) {
+      error.value = (err as { data?: { message?: string } })?.data?.message ?? 'タスクの作成に失敗しました'
+      return null
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  async function updateTask(taskId: string, payload: Partial<CreateTaskPayload> & { status?: TaskStatus }): Promise<TaskData | null> {
+    isLoading.value = true
+    error.value = null
+    try {
+      const res = await $fetch<{ task: TaskData }>(`/api/v1/tasks/${taskId}`, {
+        method: 'PATCH',
+        body: payload,
+      })
+      await fetchTasks()
+      return res.task
+    } catch (err: unknown) {
+      error.value = (err as { data?: { message?: string } })?.data?.message ?? 'タスクの更新に失敗しました'
+      return null
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  async function completeTask(taskId: string): Promise<TaskData | null> {
+    isLoading.value = true
+    error.value = null
+    try {
+      const res = await $fetch<{ task: TaskData }>(`/api/v1/tasks/${taskId}/complete`, {
+        method: 'POST',
+      })
+      await fetchTasks()
+      return res.task
+    } catch (err: unknown) {
+      error.value = (err as { data?: { message?: string } })?.data?.message ?? 'タスクの完了に失敗しました'
+      return null
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  async function deleteTask(taskId: string): Promise<boolean> {
+    isLoading.value = true
+    error.value = null
+    try {
+      await $fetch(`/api/v1/tasks/${taskId}`, { method: 'DELETE' })
+      await fetchTasks()
+      return true
+    } catch (err: unknown) {
+      error.value = (err as { data?: { message?: string } })?.data?.message ?? 'タスクの削除に失敗しました'
+      return false
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  async function generateTasks(options?: { use_template?: boolean; overwrite?: boolean }): Promise<number> {
+    isLoading.value = true
+    error.value = null
+    try {
+      const res = await $fetch<{ tasks: TaskData[]; summary: { generated: number } }>(`/api/v1/events/${eventId}/tasks/generate`, {
+        method: 'POST',
+        body: options ?? {},
+      })
+      await fetchTasks()
+      return res.summary.generated
+    } catch (err: unknown) {
+      error.value = (err as { data?: { message?: string } })?.data?.message ?? 'タスクの自動生成に失敗しました'
+      return 0
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  return {
+    tasks,
+    summary,
+    isLoading,
+    error,
+    fetchTasks,
+    createTask,
+    updateTask,
+    completeTask,
+    deleteTask,
+    generateTasks,
+  }
+}

--- a/pages/events/[id]/tasks.vue
+++ b/pages/events/[id]/tasks.vue
@@ -1,0 +1,370 @@
+<script setup lang="ts">
+// EVT-010-014: イベントタスクボード
+// 仕様書: docs/design/features/project/EVT-010-014_master-schedule.md §6
+import type { CreateTaskPayload, TaskStatus, TaskPriority } from '~/composables/useTasks'
+
+definePageMeta({ layout: 'dashboard' })
+
+const route = useRoute()
+const eventId = route.params.id as string
+
+const {
+  tasks,
+  summary,
+  isLoading,
+  error,
+  fetchTasks,
+  createTask,
+  updateTask,
+  completeTask,
+  deleteTask,
+  generateTasks,
+} = useTasks(eventId)
+
+// 初期読み込み
+onMounted(() => {
+  fetchTasks()
+})
+
+// フィルタ
+const roleFilter = ref<string>('')
+const statusFilter = ref<string>('')
+
+async function applyFilter() {
+  await fetchTasks({
+    role: roleFilter.value || undefined,
+    status: statusFilter.value || undefined,
+  })
+}
+
+watch([roleFilter, statusFilter], () => {
+  applyFilter()
+})
+
+// モーダル制御
+const showCreateModal = ref(false)
+const showDeleteConfirm = ref(false)
+const deleteTargetId = ref<string | null>(null)
+
+const form = ref<CreateTaskPayload>({
+  title: '',
+  description: '',
+  assigned_role: '',
+  priority: 'medium',
+  relative_day: undefined,
+  sort_order: 0,
+})
+
+function openCreateModal() {
+  form.value = {
+    title: '',
+    description: '',
+    assigned_role: '',
+    priority: 'medium',
+    relative_day: undefined,
+    sort_order: 0,
+  }
+  showCreateModal.value = true
+}
+
+async function handleCreate() {
+  const result = await createTask(form.value)
+  if (result) {
+    showCreateModal.value = false
+  }
+}
+
+async function handleStatusChange(taskId: string, newStatus: TaskStatus) {
+  if (newStatus === 'completed') {
+    await completeTask(taskId)
+  } else {
+    await updateTask(taskId, { status: newStatus })
+  }
+}
+
+function confirmDelete(id: string) {
+  deleteTargetId.value = id
+  showDeleteConfirm.value = true
+}
+
+async function handleDelete() {
+  if (deleteTargetId.value) {
+    await deleteTask(deleteTargetId.value)
+    showDeleteConfirm.value = false
+    deleteTargetId.value = null
+  }
+}
+
+async function handleGenerate() {
+  await generateTasks({ use_template: true })
+}
+
+// 日付フォーマット
+function formatDate(dateStr: string | null): string {
+  if (!dateStr) return '未設定'
+  const d = new Date(dateStr)
+  return d.toLocaleDateString('ja-JP', {
+    month: 'short',
+    day: 'numeric',
+    weekday: 'short',
+  })
+}
+
+// 期限超過チェック
+function isOverdue(task: { due_at: string | null; status: string }): boolean {
+  if (!task.due_at || task.status === 'completed' || task.status === 'skipped') return false
+  return new Date(task.due_at) < new Date()
+}
+</script>
+
+<template>
+  <div class="space-y-6">
+    <!-- ヘッダー -->
+    <div class="flex items-center justify-between">
+      <div>
+        <h1 class="text-2xl font-bold">タスク管理</h1>
+        <p class="text-sm text-gray-500 mt-1">
+          イベントのタスク・締め切りを管理します
+        </p>
+      </div>
+      <div class="flex gap-2">
+        <UButton
+          icon="i-heroicons-sparkles"
+          label="自動生成"
+          variant="outline"
+          @click="handleGenerate"
+        />
+        <UButton
+          icon="i-heroicons-plus"
+          label="タスク追加"
+          color="primary"
+          @click="openCreateModal"
+        />
+      </div>
+    </div>
+
+    <!-- 進捗サマリー -->
+    <div class="grid grid-cols-2 md:grid-cols-6 gap-4">
+      <UCard>
+        <div class="text-center">
+          <div class="text-2xl font-bold">{{ summary.total }}</div>
+          <div class="text-xs text-gray-500">全タスク</div>
+        </div>
+      </UCard>
+      <UCard>
+        <div class="text-center">
+          <div class="text-2xl font-bold text-gray-500">{{ summary.pending }}</div>
+          <div class="text-xs text-gray-500">未着手</div>
+        </div>
+      </UCard>
+      <UCard>
+        <div class="text-center">
+          <div class="text-2xl font-bold text-blue-500">{{ summary.inProgress }}</div>
+          <div class="text-xs text-gray-500">進行中</div>
+        </div>
+      </UCard>
+      <UCard>
+        <div class="text-center">
+          <div class="text-2xl font-bold text-green-500">{{ summary.completed }}</div>
+          <div class="text-xs text-gray-500">完了</div>
+        </div>
+      </UCard>
+      <UCard>
+        <div class="text-center">
+          <div class="text-2xl font-bold text-yellow-500">{{ summary.skipped }}</div>
+          <div class="text-xs text-gray-500">スキップ</div>
+        </div>
+      </UCard>
+      <UCard>
+        <div class="text-center">
+          <div class="text-2xl font-bold text-red-500">{{ summary.overdue }}</div>
+          <div class="text-xs text-gray-500">期限超過</div>
+        </div>
+      </UCard>
+    </div>
+
+    <!-- 進捗バー -->
+    <UProgress :value="calculateProgress(summary)" color="primary" />
+
+    <!-- フィルタ -->
+    <div class="flex gap-4">
+      <USelectMenu
+        v-model="roleFilter"
+        :items="[
+          { label: '全ロール', value: '' },
+          { label: '主催者', value: 'organizer' },
+          { label: '会場担当', value: 'venue' },
+          { label: '配信担当', value: 'streaming' },
+          { label: '企画代行', value: 'event_planner' },
+        ]"
+        value-key="value"
+        placeholder="ロールで絞込"
+      />
+      <USelectMenu
+        v-model="statusFilter"
+        :items="[
+          { label: '全ステータス', value: '' },
+          { label: '未着手', value: 'pending' },
+          { label: '進行中', value: 'in_progress' },
+          { label: '完了', value: 'completed' },
+          { label: 'スキップ', value: 'skipped' },
+        ]"
+        value-key="value"
+        placeholder="ステータスで絞込"
+      />
+    </div>
+
+    <!-- エラー -->
+    <UAlert v-if="error" color="error" :title="error" icon="i-heroicons-exclamation-triangle" />
+
+    <!-- ローディング -->
+    <div v-if="isLoading" class="space-y-4">
+      <USkeleton v-for="i in 5" :key="i" class="h-16 w-full" />
+    </div>
+
+    <!-- タスク一覧 -->
+    <UCard v-else-if="tasks.length > 0">
+      <div class="divide-y">
+        <div
+          v-for="t in tasks"
+          :key="t.id"
+          class="flex items-center justify-between py-3 first:pt-0 last:pb-0"
+          :class="{ 'bg-red-50': isOverdue(t) }"
+        >
+          <div class="flex items-center gap-3 flex-1 min-w-0">
+            <!-- ステータスボタン -->
+            <UButton
+              v-if="t.status !== 'completed'"
+              icon="i-heroicons-check-circle"
+              variant="ghost"
+              size="xs"
+              color="neutral"
+              @click="handleStatusChange(t.id, 'completed')"
+            />
+            <UIcon
+              v-else
+              name="i-heroicons-check-circle-solid"
+              class="w-5 h-5 text-green-500"
+            />
+
+            <div class="flex-1 min-w-0">
+              <div class="flex items-center gap-2">
+                <span
+                  class="font-medium truncate"
+                  :class="{ 'line-through text-gray-400': t.status === 'completed' || t.status === 'skipped' }"
+                >
+                  {{ t.title }}
+                </span>
+                <UBadge :color="getTaskPriorityColor(t.priority as TaskPriority)" variant="subtle" size="xs">
+                  {{ getTaskPriorityLabel(t.priority as TaskPriority) }}
+                </UBadge>
+              </div>
+              <div class="flex items-center gap-3 mt-1 text-xs text-gray-500">
+                <span>{{ getTaskRoleLabel(t.assigned_role) }}</span>
+                <span v-if="t.relative_day !== null">{{ formatRelativeDay(t.relative_day) }}</span>
+                <span :class="{ 'text-red-500 font-medium': isOverdue(t) }">{{ formatDate(t.due_at) }}</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="flex items-center gap-2 ml-4">
+            <UBadge :color="getTaskStatusColor(t.status as TaskStatus)" variant="subtle" size="sm">
+              {{ getTaskStatusLabel(t.status as TaskStatus) }}
+            </UBadge>
+            <UButton
+              icon="i-heroicons-trash"
+              color="error"
+              variant="ghost"
+              size="xs"
+              @click="confirmDelete(t.id)"
+            />
+          </div>
+        </div>
+      </div>
+    </UCard>
+
+    <!-- 空状態 -->
+    <UCard v-else>
+      <div class="text-center py-12">
+        <div class="text-gray-400 mb-4">
+          <UIcon name="i-heroicons-clipboard-document-list" class="w-12 h-12" />
+        </div>
+        <h3 class="text-lg font-medium text-gray-900">タスクがありません</h3>
+        <p class="text-gray-500 mt-1">テンプレートから自動生成するか、手動でタスクを追加しましょう</p>
+        <div class="flex justify-center gap-3 mt-4">
+          <UButton icon="i-heroicons-sparkles" label="テンプレートから自動生成" variant="outline" @click="handleGenerate" />
+          <UButton icon="i-heroicons-plus" label="手動追加" color="primary" @click="openCreateModal" />
+        </div>
+      </div>
+    </UCard>
+
+    <!-- タスク作成モーダル -->
+    <UModal v-model:open="showCreateModal">
+      <template #header>
+        <h3 class="text-lg font-semibold">タスク追加</h3>
+      </template>
+      <template #body>
+        <div class="space-y-4">
+          <UFormField label="タスク名" required>
+            <UInput v-model="form.title" placeholder="企画書作成" />
+          </UFormField>
+          <UFormField label="説明">
+            <UTextarea v-model="form.description" placeholder="タスクの詳細..." :rows="2" />
+          </UFormField>
+          <div class="grid grid-cols-2 gap-4">
+            <UFormField label="担当ロール">
+              <USelectMenu
+                v-model="form.assigned_role"
+                :items="[
+                  { label: '主催者', value: 'organizer' },
+                  { label: '会場担当', value: 'venue' },
+                  { label: '配信担当', value: 'streaming' },
+                  { label: '企画代行', value: 'event_planner' },
+                  { label: '登壇者', value: 'speaker' },
+                ]"
+                value-key="value"
+                placeholder="選択"
+              />
+            </UFormField>
+            <UFormField label="優先度">
+              <USelectMenu
+                v-model="form.priority"
+                :items="[
+                  { label: '高', value: 'high' },
+                  { label: '中', value: 'medium' },
+                  { label: '低', value: 'low' },
+                ]"
+                value-key="value"
+              />
+            </UFormField>
+          </div>
+          <UFormField label="相対日（D-30=-30, D+1=1）">
+            <UInput v-model.number="form.relative_day" type="number" placeholder="-7" />
+          </UFormField>
+        </div>
+      </template>
+      <template #footer>
+        <div class="flex justify-end gap-3">
+          <UButton label="キャンセル" variant="ghost" @click="showCreateModal = false" />
+          <UButton label="追加" color="primary" :loading="isLoading" @click="handleCreate" />
+        </div>
+      </template>
+    </UModal>
+
+    <!-- 削除確認モーダル -->
+    <UModal v-model:open="showDeleteConfirm">
+      <template #header>
+        <h3 class="text-lg font-semibold">タスク削除の確認</h3>
+      </template>
+      <template #body>
+        <p>このタスクを削除してもよろしいですか？この操作は取り消せません。</p>
+      </template>
+      <template #footer>
+        <div class="flex justify-end gap-3">
+          <UButton label="キャンセル" variant="ghost" @click="showDeleteConfirm = false" />
+          <UButton label="削除" color="error" @click="handleDelete" />
+        </div>
+      </template>
+    </UModal>
+  </div>
+</template>

--- a/server/api/v1/events/[eventId]/tasks/generate.post.ts
+++ b/server/api/v1/events/[eventId]/tasks/generate.post.ts
@@ -1,0 +1,154 @@
+// EVT-010-014 §5.6: タスクテンプレート自動生成 API
+// POST /api/v1/events/:eventId/tasks/generate
+import { eq, and, or, isNull } from 'drizzle-orm'
+import { ulid } from 'ulid'
+import { db } from '~/server/utils/db'
+import { requirePermission } from '~/server/utils/permission'
+import { handleApiError } from '~/server/utils/api-error'
+import { generateTasksSchema, calculateDueAt } from '~/server/utils/task-validation'
+import { task, event, taskTemplate } from '~/server/database/schema'
+
+export default defineEventHandler(async (h3Event) => {
+  try {
+    const ctx = await requirePermission(h3Event, 'create', 'task')
+    const eventId = getRouterParam(h3Event, 'eventId')
+
+    if (!eventId) {
+      throw createError({ statusCode: 400, statusMessage: 'VALIDATION_ERROR', message: 'イベントIDが指定されていません' })
+    }
+
+    const body = await readBody(h3Event)
+    const parsed = generateTasksSchema.safeParse(body ?? {})
+    if (!parsed.success) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: 'VALIDATION_ERROR',
+        message: 'バリデーションエラー',
+        data: { code: 'VALIDATION_ERROR', details: parsed.error.flatten().fieldErrors },
+      })
+    }
+
+    const data = parsed.data
+
+    // イベント存在確認
+    const eventRecord = await db.select()
+      .from(event)
+      .where(and(eq(event.id, eventId), eq(event.tenantId, ctx.tenantId)))
+      .limit(1)
+
+    if (eventRecord.length === 0) {
+      throw createError({ statusCode: 404, statusMessage: 'NOT_FOUND', message: 'イベントが見つかりません' })
+    }
+
+    const evt = eventRecord[0]
+
+    // overwrite=true の場合は既存タスクを削除
+    if (data.overwrite) {
+      await db.delete(task).where(eq(task.eventId, eventId))
+    }
+
+    const generatedTasks: typeof task.$inferInsert[] = []
+    let fromTemplate = 0
+    let fromAI = 0
+
+    if (data.use_template) {
+      // §5.6 ビジネスルール: テナント独自テンプレートを優先
+      const templates = await db.select()
+        .from(taskTemplate)
+        .where(and(
+          eq(taskTemplate.eventType, evt.eventType),
+          eq(taskTemplate.isActive, true),
+          or(
+            eq(taskTemplate.tenantId, ctx.tenantId),
+            isNull(taskTemplate.tenantId),
+          ),
+        ))
+        .orderBy(taskTemplate.sortOrder)
+
+      // テナント独自があればそちらを優先
+      const tenantTemplates = templates.filter(t => t.tenantId === ctx.tenantId)
+      const systemTemplates = templates.filter(t => t.tenantId === null)
+      const selectedTemplates = tenantTemplates.length > 0 ? tenantTemplates : systemTemplates
+
+      for (const tmpl of selectedTemplates) {
+        const dueAt = evt.startAt ? calculateDueAt(evt.startAt, tmpl.relativeDay) : null
+
+        generatedTasks.push({
+          id: ulid(),
+          eventId,
+          tenantId: ctx.tenantId,
+          title: tmpl.title,
+          description: tmpl.description,
+          assignedRole: tmpl.assignedRole,
+          assignedUserId: null,
+          status: 'pending',
+          priority: tmpl.priority,
+          relativeDay: tmpl.relativeDay,
+          dueAt,
+          completedAt: null,
+          sortOrder: tmpl.sortOrder,
+          templateId: tmpl.id,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        } as never)
+      }
+      fromTemplate = generatedTasks.length
+    }
+
+    // テンプレートがない場合のフォールバック: デフォルトタスクセットを生成
+    if (generatedTasks.length === 0) {
+      const defaultTasks = [
+        { title: '企画書作成', assignedRole: 'organizer', relativeDay: -30, priority: 'high' as const, sortOrder: 1 },
+        { title: '会場レイアウト確認', assignedRole: 'venue', relativeDay: -14, priority: 'medium' as const, sortOrder: 2 },
+        { title: '配信機材手配', assignedRole: 'streaming', relativeDay: -14, priority: 'medium' as const, sortOrder: 3 },
+        { title: '参加者募集開始', assignedRole: 'organizer', relativeDay: -21, priority: 'high' as const, sortOrder: 4 },
+        { title: 'リハーサル', assignedRole: 'organizer', relativeDay: -1, priority: 'high' as const, sortOrder: 5 },
+        { title: '当日運営', assignedRole: 'organizer', relativeDay: 0, priority: 'high' as const, sortOrder: 6 },
+        { title: '振り返りレポート作成', assignedRole: 'organizer', relativeDay: 1, priority: 'medium' as const, sortOrder: 7 },
+      ]
+
+      for (const dt of defaultTasks) {
+        const dueAt = evt.startAt ? calculateDueAt(evt.startAt, dt.relativeDay) : null
+        generatedTasks.push({
+          id: ulid(),
+          eventId,
+          tenantId: ctx.tenantId,
+          title: dt.title,
+          description: null,
+          assignedRole: dt.assignedRole,
+          assignedUserId: null,
+          status: 'pending',
+          priority: dt.priority,
+          relativeDay: dt.relativeDay,
+          dueAt,
+          completedAt: null,
+          sortOrder: dt.sortOrder,
+          templateId: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        } as never)
+      }
+      fromAI = generatedTasks.length
+    }
+
+    // バルクインサート
+    let insertedTasks: unknown[] = []
+    if (generatedTasks.length > 0) {
+      insertedTasks = await db.insert(task)
+        .values(generatedTasks as never[])
+        .returning()
+    }
+
+    setResponseStatus(h3Event, 201)
+    return {
+      tasks: insertedTasks,
+      summary: {
+        generated: insertedTasks.length,
+        fromTemplate,
+        fromAI,
+      },
+    }
+  } catch (err) {
+    handleApiError(err)
+  }
+})

--- a/server/api/v1/events/[eventId]/tasks/index.get.ts
+++ b/server/api/v1/events/[eventId]/tasks/index.get.ts
@@ -1,0 +1,67 @@
+// EVT-010-014 §5.1: タスク一覧取得 API
+// GET /api/v1/events/:eventId/tasks
+import { eq, and } from 'drizzle-orm'
+import { db } from '~/server/utils/db'
+import { requirePermission } from '~/server/utils/permission'
+import { handleApiError } from '~/server/utils/api-error'
+import { task, event } from '~/server/database/schema'
+
+export default defineEventHandler(async (h3Event) => {
+  try {
+    const ctx = await requirePermission(h3Event, 'read', 'task')
+    const eventId = getRouterParam(h3Event, 'eventId')
+
+    if (!eventId) {
+      throw createError({ statusCode: 400, statusMessage: 'VALIDATION_ERROR', message: 'イベントIDが指定されていません' })
+    }
+
+    // イベント存在確認 + テナント分離
+    const eventRecord = await db.select({ id: event.id })
+      .from(event)
+      .where(and(eq(event.id, eventId), eq(event.tenantId, ctx.tenantId)))
+      .limit(1)
+
+    if (eventRecord.length === 0) {
+      throw createError({ statusCode: 404, statusMessage: 'NOT_FOUND', message: 'イベントが見つかりません' })
+    }
+
+    const query = getQuery(h3Event)
+
+    // フィルタ構築
+    const conditions = [eq(task.eventId, eventId), eq(task.tenantId, ctx.tenantId)]
+
+    if (query.role && typeof query.role === 'string') {
+      conditions.push(eq(task.assignedRole as never, query.role as never))
+    }
+
+    if (query.status && typeof query.status === 'string') {
+      conditions.push(eq(task.status, query.status))
+    }
+
+    if (query.assigned_user_id && typeof query.assigned_user_id === 'string') {
+      conditions.push(eq(task.assignedUserId as never, query.assigned_user_id as never))
+    }
+
+    const whereClause = and(...conditions)
+
+    const tasks = await db.select()
+      .from(task)
+      .where(whereClause)
+      .orderBy(task.sortOrder, task.dueAt)
+
+    // サマリー計算
+    const now = new Date()
+    const summary = {
+      total: tasks.length,
+      pending: tasks.filter(t => t.status === 'pending').length,
+      inProgress: tasks.filter(t => t.status === 'in_progress').length,
+      completed: tasks.filter(t => t.status === 'completed').length,
+      skipped: tasks.filter(t => t.status === 'skipped').length,
+      overdue: tasks.filter(t => t.dueAt && t.dueAt < now && t.status !== 'completed' && t.status !== 'skipped').length,
+    }
+
+    return { tasks, summary }
+  } catch (err) {
+    handleApiError(err)
+  }
+})

--- a/server/api/v1/events/[eventId]/tasks/index.post.ts
+++ b/server/api/v1/events/[eventId]/tasks/index.post.ts
@@ -1,0 +1,92 @@
+// EVT-010-014 §5.2: タスク作成 API
+// POST /api/v1/events/:eventId/tasks
+import { eq, and, sql } from 'drizzle-orm'
+import { ulid } from 'ulid'
+import { db } from '~/server/utils/db'
+import { requirePermission } from '~/server/utils/permission'
+import { handleApiError } from '~/server/utils/api-error'
+import { createTaskSchema, calculateDueAt, MAX_TASKS_PER_EVENT } from '~/server/utils/task-validation'
+import { task, event } from '~/server/database/schema'
+
+export default defineEventHandler(async (h3Event) => {
+  try {
+    const ctx = await requirePermission(h3Event, 'create', 'task')
+    const eventId = getRouterParam(h3Event, 'eventId')
+
+    if (!eventId) {
+      throw createError({ statusCode: 400, statusMessage: 'VALIDATION_ERROR', message: 'イベントIDが指定されていません' })
+    }
+
+    const body = await readBody(h3Event)
+
+    // Zod バリデーション
+    const parsed = createTaskSchema.safeParse(body)
+    if (!parsed.success) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: 'VALIDATION_ERROR',
+        message: 'バリデーションエラー',
+        data: { code: 'VALIDATION_ERROR', details: parsed.error.flatten().fieldErrors },
+      })
+    }
+
+    const data = parsed.data
+
+    // イベント存在確認 + テナント分離
+    const eventRecord = await db.select()
+      .from(event)
+      .where(and(eq(event.id, eventId), eq(event.tenantId, ctx.tenantId)))
+      .limit(1)
+
+    if (eventRecord.length === 0) {
+      throw createError({ statusCode: 404, statusMessage: 'NOT_FOUND', message: 'イベントが見つかりません' })
+    }
+
+    // §3-F: 1イベントあたりタスク数上限チェック
+    const countResult = await db.select({ count: sql<number>`count(*)::int` })
+      .from(task)
+      .where(eq(task.eventId, eventId))
+
+    if ((countResult[0]?.count ?? 0) >= MAX_TASKS_PER_EVENT) {
+      throw createError({
+        statusCode: 409,
+        statusMessage: 'SCHEDULE_CONFLICT',
+        message: `タスク数が上限(${MAX_TASKS_PER_EVENT}件)に達しています`,
+      })
+    }
+
+    // 締め切り計算
+    let dueAt: Date | null = null
+    if (data.relative_day !== undefined && eventRecord[0].startAt) {
+      dueAt = calculateDueAt(eventRecord[0].startAt, data.relative_day)
+    } else if (data.due_at) {
+      dueAt = new Date(data.due_at)
+    }
+
+    const result = await db.insert(task)
+      .values({
+        id: ulid(),
+        eventId,
+        tenantId: ctx.tenantId,
+        title: data.title,
+        description: data.description ?? null,
+        assignedRole: data.assigned_role ?? null,
+        assignedUserId: data.assigned_user_id ?? null,
+        status: 'pending',
+        priority: data.priority ?? 'medium',
+        relativeDay: data.relative_day ?? null,
+        dueAt,
+        completedAt: null,
+        sortOrder: data.sort_order ?? 0,
+        templateId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as never)
+      .returning()
+
+    setResponseStatus(h3Event, 201)
+    return { task: result[0] }
+  } catch (err) {
+    handleApiError(err)
+  }
+})

--- a/server/api/v1/task-templates/[templateId]/index.delete.ts
+++ b/server/api/v1/task-templates/[templateId]/index.delete.ts
@@ -1,0 +1,37 @@
+// EVT-010-014 §5.10: タスクテンプレート削除 API
+// DELETE /api/v1/task-templates/:templateId
+import { eq, and } from 'drizzle-orm'
+import { db } from '~/server/utils/db'
+import { requirePermission } from '~/server/utils/permission'
+import { handleApiError } from '~/server/utils/api-error'
+import { taskTemplate } from '~/server/database/schema'
+
+export default defineEventHandler(async (h3Event) => {
+  try {
+    const ctx = await requirePermission(h3Event, 'delete', 'task')
+    const templateId = getRouterParam(h3Event, 'templateId')
+
+    if (!templateId) {
+      throw createError({ statusCode: 400, statusMessage: 'VALIDATION_ERROR', message: 'テンプレートIDが指定されていません' })
+    }
+
+    // 存在確認（自テナントのみ削除可能）
+    const existing = await db.select({ id: taskTemplate.id })
+      .from(taskTemplate)
+      .where(and(
+        eq(taskTemplate.id, templateId),
+        eq(taskTemplate.tenantId, ctx.tenantId),
+      ))
+      .limit(1)
+
+    if (existing.length === 0) {
+      throw createError({ statusCode: 404, statusMessage: 'NOT_FOUND', message: 'テンプレートが見つかりません' })
+    }
+
+    await db.delete(taskTemplate).where(eq(taskTemplate.id, templateId))
+
+    return { success: true }
+  } catch (err) {
+    handleApiError(err)
+  }
+})

--- a/server/api/v1/task-templates/[templateId]/index.patch.ts
+++ b/server/api/v1/task-templates/[templateId]/index.patch.ts
@@ -1,0 +1,64 @@
+// EVT-010-014 §5.9: タスクテンプレート更新 API
+// PATCH /api/v1/task-templates/:templateId
+import { eq, and } from 'drizzle-orm'
+import { db } from '~/server/utils/db'
+import { requirePermission } from '~/server/utils/permission'
+import { handleApiError } from '~/server/utils/api-error'
+import { updateTaskTemplateSchema } from '~/server/utils/task-validation'
+import { taskTemplate } from '~/server/database/schema'
+
+export default defineEventHandler(async (h3Event) => {
+  try {
+    const ctx = await requirePermission(h3Event, 'update', 'task')
+    const templateId = getRouterParam(h3Event, 'templateId')
+
+    if (!templateId) {
+      throw createError({ statusCode: 400, statusMessage: 'VALIDATION_ERROR', message: 'テンプレートIDが指定されていません' })
+    }
+
+    const body = await readBody(h3Event)
+    const parsed = updateTaskTemplateSchema.safeParse(body)
+    if (!parsed.success) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: 'VALIDATION_ERROR',
+        message: 'バリデーションエラー',
+        data: { code: 'VALIDATION_ERROR', details: parsed.error.flatten().fieldErrors },
+      })
+    }
+
+    // 存在確認（自テナントのみ更新可能）
+    const existing = await db.select()
+      .from(taskTemplate)
+      .where(and(
+        eq(taskTemplate.id, templateId),
+        eq(taskTemplate.tenantId, ctx.tenantId),
+      ))
+      .limit(1)
+
+    if (existing.length === 0) {
+      throw createError({ statusCode: 404, statusMessage: 'NOT_FOUND', message: 'テンプレートが見つかりません' })
+    }
+
+    const data = parsed.data
+    const updatePayload: Record<string, unknown> = { updatedAt: new Date() }
+
+    if (data.event_type !== undefined) updatePayload.eventType = data.event_type
+    if (data.title !== undefined) updatePayload.title = data.title
+    if (data.description !== undefined) updatePayload.description = data.description
+    if (data.assigned_role !== undefined) updatePayload.assignedRole = data.assigned_role
+    if (data.relative_day !== undefined) updatePayload.relativeDay = data.relative_day
+    if (data.priority !== undefined) updatePayload.priority = data.priority
+    if (data.sort_order !== undefined) updatePayload.sortOrder = data.sort_order
+    if (data.is_active !== undefined) updatePayload.isActive = data.is_active
+
+    const result = await db.update(taskTemplate)
+      .set(updatePayload as never)
+      .where(eq(taskTemplate.id, templateId))
+      .returning()
+
+    return { template: result[0] }
+  } catch (err) {
+    handleApiError(err)
+  }
+})

--- a/server/api/v1/task-templates/index.get.ts
+++ b/server/api/v1/task-templates/index.get.ts
@@ -1,0 +1,39 @@
+// EVT-010-014 §5.7: タスクテンプレート一覧取得 API
+// GET /api/v1/task-templates
+import { eq, and, or, isNull } from 'drizzle-orm'
+import { db } from '~/server/utils/db'
+import { requirePermission } from '~/server/utils/permission'
+import { handleApiError } from '~/server/utils/api-error'
+import { taskTemplate } from '~/server/database/schema'
+
+export default defineEventHandler(async (h3Event) => {
+  try {
+    const ctx = await requirePermission(h3Event, 'read', 'task')
+    const query = getQuery(h3Event)
+
+    const conditions = [
+      or(
+        eq(taskTemplate.tenantId, ctx.tenantId),
+        isNull(taskTemplate.tenantId),
+      ),
+    ]
+
+    if (query.event_type && typeof query.event_type === 'string') {
+      conditions.push(eq(taskTemplate.eventType, query.event_type))
+    }
+
+    if (query.is_active !== undefined) {
+      const isActive = query.is_active === 'true' || query.is_active === true
+      conditions.push(eq(taskTemplate.isActive, isActive as boolean))
+    }
+
+    const templates = await db.select()
+      .from(taskTemplate)
+      .where(and(...conditions))
+      .orderBy(taskTemplate.eventType, taskTemplate.sortOrder)
+
+    return { templates }
+  } catch (err) {
+    handleApiError(err)
+  }
+})

--- a/server/api/v1/task-templates/index.post.ts
+++ b/server/api/v1/task-templates/index.post.ts
@@ -1,0 +1,49 @@
+// EVT-010-014 §5.8: タスクテンプレート作成 API
+// POST /api/v1/task-templates
+import { ulid } from 'ulid'
+import { db } from '~/server/utils/db'
+import { requirePermission } from '~/server/utils/permission'
+import { handleApiError } from '~/server/utils/api-error'
+import { createTaskTemplateSchema } from '~/server/utils/task-validation'
+import { taskTemplate } from '~/server/database/schema'
+
+export default defineEventHandler(async (h3Event) => {
+  try {
+    const ctx = await requirePermission(h3Event, 'create', 'task')
+    const body = await readBody(h3Event)
+
+    const parsed = createTaskTemplateSchema.safeParse(body)
+    if (!parsed.success) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: 'VALIDATION_ERROR',
+        message: 'バリデーションエラー',
+        data: { code: 'VALIDATION_ERROR', details: parsed.error.flatten().fieldErrors },
+      })
+    }
+
+    const data = parsed.data
+
+    const result = await db.insert(taskTemplate)
+      .values({
+        id: ulid(),
+        tenantId: ctx.tenantId,
+        eventType: data.event_type,
+        title: data.title,
+        description: data.description ?? null,
+        assignedRole: data.assigned_role,
+        relativeDay: data.relative_day,
+        priority: data.priority ?? 'medium',
+        sortOrder: data.sort_order ?? 0,
+        isActive: data.is_active ?? true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as never)
+      .returning()
+
+    setResponseStatus(h3Event, 201)
+    return { template: result[0] }
+  } catch (err) {
+    handleApiError(err)
+  }
+})

--- a/server/api/v1/tasks/[taskId]/complete.post.ts
+++ b/server/api/v1/tasks/[taskId]/complete.post.ts
@@ -1,0 +1,46 @@
+// EVT-010-014 §5.4: タスク完了 API
+// POST /api/v1/tasks/:taskId/complete
+import { eq, and } from 'drizzle-orm'
+import { db } from '~/server/utils/db'
+import { requirePermission } from '~/server/utils/permission'
+import { handleApiError } from '~/server/utils/api-error'
+import { task } from '~/server/database/schema'
+
+export default defineEventHandler(async (h3Event) => {
+  try {
+    const ctx = await requirePermission(h3Event, 'update', 'task')
+    const taskId = getRouterParam(h3Event, 'taskId')
+
+    if (!taskId) {
+      throw createError({ statusCode: 400, statusMessage: 'VALIDATION_ERROR', message: 'タスクIDが指定されていません' })
+    }
+
+    // 存在確認 + テナント分離
+    const existing = await db.select()
+      .from(task)
+      .where(and(eq(task.id, taskId), eq(task.tenantId, ctx.tenantId)))
+      .limit(1)
+
+    if (existing.length === 0) {
+      throw createError({ statusCode: 404, statusMessage: 'NOT_FOUND', message: 'タスクが見つかりません' })
+    }
+
+    // §5.4: 既に完了済みの場合は 409
+    if (existing[0].status === 'completed') {
+      throw createError({ statusCode: 409, statusMessage: 'CONFLICT', message: 'このタスクは既に完了しています' })
+    }
+
+    const result = await db.update(task)
+      .set({
+        status: 'completed',
+        completedAt: new Date(),
+        updatedAt: new Date(),
+      } as never)
+      .where(eq(task.id, taskId))
+      .returning()
+
+    return { task: result[0] }
+  } catch (err) {
+    handleApiError(err)
+  }
+})

--- a/server/api/v1/tasks/[taskId]/index.delete.ts
+++ b/server/api/v1/tasks/[taskId]/index.delete.ts
@@ -1,0 +1,34 @@
+// EVT-010-014 §5.5: タスク削除 API
+// DELETE /api/v1/tasks/:taskId
+import { eq, and } from 'drizzle-orm'
+import { db } from '~/server/utils/db'
+import { requirePermission } from '~/server/utils/permission'
+import { handleApiError } from '~/server/utils/api-error'
+import { task } from '~/server/database/schema'
+
+export default defineEventHandler(async (h3Event) => {
+  try {
+    const ctx = await requirePermission(h3Event, 'delete', 'task')
+    const taskId = getRouterParam(h3Event, 'taskId')
+
+    if (!taskId) {
+      throw createError({ statusCode: 400, statusMessage: 'VALIDATION_ERROR', message: 'タスクIDが指定されていません' })
+    }
+
+    // 存在確認 + テナント分離
+    const existing = await db.select({ id: task.id })
+      .from(task)
+      .where(and(eq(task.id, taskId), eq(task.tenantId, ctx.tenantId)))
+      .limit(1)
+
+    if (existing.length === 0) {
+      throw createError({ statusCode: 404, statusMessage: 'NOT_FOUND', message: 'タスクが見つかりません' })
+    }
+
+    await db.delete(task).where(eq(task.id, taskId))
+
+    return { success: true }
+  } catch (err) {
+    handleApiError(err)
+  }
+})

--- a/server/api/v1/tasks/[taskId]/index.patch.ts
+++ b/server/api/v1/tasks/[taskId]/index.patch.ts
@@ -1,0 +1,102 @@
+// EVT-010-014 §5.3: タスク更新 API
+// PATCH /api/v1/tasks/:taskId
+import { eq, and } from 'drizzle-orm'
+import { db } from '~/server/utils/db'
+import { requirePermission } from '~/server/utils/permission'
+import { handleApiError } from '~/server/utils/api-error'
+import { updateTaskSchema, isValidTaskStatusTransition, calculateDueAt } from '~/server/utils/task-validation'
+import { task, event } from '~/server/database/schema'
+import type { TaskStatus } from '~/server/utils/task-validation'
+
+export default defineEventHandler(async (h3Event) => {
+  try {
+    const ctx = await requirePermission(h3Event, 'update', 'task')
+    const taskId = getRouterParam(h3Event, 'taskId')
+
+    if (!taskId) {
+      throw createError({ statusCode: 400, statusMessage: 'VALIDATION_ERROR', message: 'タスクIDが指定されていません' })
+    }
+
+    const body = await readBody(h3Event)
+    const parsed = updateTaskSchema.safeParse(body)
+    if (!parsed.success) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: 'VALIDATION_ERROR',
+        message: 'バリデーションエラー',
+        data: { code: 'VALIDATION_ERROR', details: parsed.error.flatten().fieldErrors },
+      })
+    }
+
+    const data = parsed.data
+
+    // 存在確認 + テナント分離
+    const existing = await db.select()
+      .from(task)
+      .where(and(eq(task.id, taskId), eq(task.tenantId, ctx.tenantId)))
+      .limit(1)
+
+    if (existing.length === 0) {
+      throw createError({ statusCode: 404, statusMessage: 'NOT_FOUND', message: 'タスクが見つかりません' })
+    }
+
+    const current = existing[0]
+
+    // ステータス遷移チェック
+    if (data.status && data.status !== current.status) {
+      if (!isValidTaskStatusTransition(current.status as TaskStatus, data.status as TaskStatus)) {
+        throw createError({
+          statusCode: 400,
+          statusMessage: 'VALIDATION_ERROR',
+          message: `ステータスを ${current.status} から ${data.status} に変更できません`,
+        })
+      }
+    }
+
+    // フィールドマッピング
+    const updatePayload: Record<string, unknown> = { updatedAt: new Date() }
+
+    if (data.title !== undefined) updatePayload.title = data.title
+    if (data.description !== undefined) updatePayload.description = data.description
+    if (data.assigned_role !== undefined) updatePayload.assignedRole = data.assigned_role
+    if (data.assigned_user_id !== undefined) updatePayload.assignedUserId = data.assigned_user_id
+    if (data.priority !== undefined) updatePayload.priority = data.priority
+    if (data.sort_order !== undefined) updatePayload.sortOrder = data.sort_order
+
+    // ステータス更新 + completedAt 自動設定
+    if (data.status !== undefined) {
+      updatePayload.status = data.status
+      if (data.status === 'completed') {
+        updatePayload.completedAt = new Date()
+      } else if (data.status === 'pending') {
+        updatePayload.completedAt = null
+      }
+    }
+
+    // 相対日変更時の dueAt 再計算
+    if (data.relative_day !== undefined) {
+      updatePayload.relativeDay = data.relative_day
+      // イベントの開催日を取得して再計算
+      const eventRecord = await db.select({ startAt: event.startAt })
+        .from(event)
+        .where(eq(event.id, current.eventId))
+        .limit(1)
+
+      if (eventRecord[0]?.startAt) {
+        updatePayload.dueAt = calculateDueAt(eventRecord[0].startAt, data.relative_day)
+      }
+    } else if (data.due_at !== undefined) {
+      updatePayload.dueAt = new Date(data.due_at)
+      updatePayload.relativeDay = null // 手動設定時は相対日をクリア
+    }
+
+    const result = await db.update(task)
+      .set(updatePayload as never)
+      .where(eq(task.id, taskId))
+      .returning()
+
+    return { task: result[0] }
+  } catch (err) {
+    handleApiError(err)
+  }
+})

--- a/server/utils/task-validation.ts
+++ b/server/utils/task-validation.ts
@@ -1,0 +1,128 @@
+// EVT-010-014: タスク・スケジュール バリデーションスキーマ
+// 仕様書: docs/design/features/project/EVT-010-014_master-schedule.md §3-F
+import { z } from 'zod'
+
+// ──────────────────────────────────────
+// 定数定義
+// ──────────────────────────────────────
+
+export const TASK_STATUSES = ['pending', 'in_progress', 'completed', 'skipped'] as const
+export type TaskStatus = typeof TASK_STATUSES[number]
+
+export const TASK_PRIORITIES = ['high', 'medium', 'low'] as const
+export type TaskPriority = typeof TASK_PRIORITIES[number]
+
+export const TASK_ROLES = ['organizer', 'venue', 'streaming', 'event_planner', 'speaker', 'vendor'] as const
+export type TaskRole = typeof TASK_ROLES[number]
+
+// §3-F 境界値
+export const MAX_TASKS_PER_EVENT = 200
+export const RELATIVE_DAY_MIN = -365
+export const RELATIVE_DAY_MAX = 365
+export const SORT_ORDER_MIN = 0
+export const SORT_ORDER_MAX = 9999
+
+// ──────────────────────────────────────
+// タスクバリデーション (§3-F)
+// ──────────────────────────────────────
+
+/** タスク作成スキーマ (§5.2) */
+export const createTaskSchema = z.object({
+  title: z.string().min(1, 'タスク名は必須です').max(200, 'タスク名は200文字以内で入力してください'),
+  description: z.string().max(2000, '説明は2000文字以内で入力してください').optional(),
+  assigned_role: z.string().max(50).optional(),
+  assigned_user_id: z.string().optional(),
+  priority: z.enum(TASK_PRIORITIES).optional().default('medium'),
+  relative_day: z.number().int().min(RELATIVE_DAY_MIN).max(RELATIVE_DAY_MAX).optional(),
+  due_at: z.string().datetime().optional(),
+  sort_order: z.number().int().min(SORT_ORDER_MIN).max(SORT_ORDER_MAX).optional(),
+}).refine(
+  data => !(data.relative_day !== undefined && data.due_at !== undefined),
+  { message: 'relative_day と due_at は同時に指定できません', path: ['relative_day'] },
+)
+
+/** タスク更新スキーマ (§5.3) */
+export const updateTaskSchema = z.object({
+  title: z.string().min(1).max(200).optional(),
+  description: z.string().max(2000).optional(),
+  assigned_role: z.string().max(50).optional(),
+  assigned_user_id: z.string().optional(),
+  status: z.enum(TASK_STATUSES).optional(),
+  priority: z.enum(TASK_PRIORITIES).optional(),
+  relative_day: z.number().int().min(RELATIVE_DAY_MIN).max(RELATIVE_DAY_MAX).optional(),
+  due_at: z.string().datetime().optional(),
+  sort_order: z.number().int().min(SORT_ORDER_MIN).max(SORT_ORDER_MAX).optional(),
+})
+
+/** タスク生成リクエストスキーマ (§5.6) */
+export const generateTasksSchema = z.object({
+  use_template: z.boolean().optional().default(true),
+  custom_prompt: z.string().max(2000).optional(),
+  overwrite: z.boolean().optional().default(false),
+})
+
+// ──────────────────────────────────────
+// テンプレートバリデーション
+// ──────────────────────────────────────
+
+/** テンプレート作成スキーマ (§5.8) */
+export const createTaskTemplateSchema = z.object({
+  event_type: z.string().min(1, 'イベント種別は必須です').max(50),
+  title: z.string().min(1, 'テンプレート名は必須です').max(200, 'テンプレート名は200文字以内で入力してください'),
+  description: z.string().max(2000).optional(),
+  assigned_role: z.string().min(1, '担当ロールは必須です').max(50),
+  relative_day: z.number().int()
+    .min(RELATIVE_DAY_MIN, `相対日は${RELATIVE_DAY_MIN}以上です`)
+    .max(RELATIVE_DAY_MAX, `相対日は${RELATIVE_DAY_MAX}以下です`),
+  priority: z.enum(TASK_PRIORITIES).optional().default('medium'),
+  sort_order: z.number().int().min(SORT_ORDER_MIN).max(SORT_ORDER_MAX).optional().default(0),
+  is_active: z.boolean().optional().default(true),
+})
+
+/** テンプレート更新スキーマ (§5.9) */
+export const updateTaskTemplateSchema = createTaskTemplateSchema.partial()
+
+// ──────────────────────────────────────
+// ステータス遷移チェック
+// ──────────────────────────────────────
+
+/** 有効なステータス遷移マップ */
+export const TASK_STATUS_TRANSITIONS: Record<TaskStatus, TaskStatus[]> = {
+  pending: ['in_progress', 'skipped'],
+  in_progress: ['completed', 'skipped', 'pending'],
+  completed: ['pending'],   // 再オープン可
+  skipped: ['pending'],     // 再オープン可
+}
+
+/** ステータス遷移チェック */
+export function isValidTaskStatusTransition(from: TaskStatus, to: TaskStatus): boolean {
+  if (from === to) return true // 同じ状態はOK
+  return TASK_STATUS_TRANSITIONS[from]?.includes(to) ?? false
+}
+
+// ──────────────────────────────────────
+// 締め切り計算
+// ──────────────────────────────────────
+
+/** 相対日から締め切り日を計算 */
+export function calculateDueAt(eventStartAt: Date | string, relativeDay: number): Date {
+  const baseDate = typeof eventStartAt === 'string' ? new Date(eventStartAt) : eventStartAt
+  const dueAt = new Date(baseDate)
+  dueAt.setDate(dueAt.getDate() + relativeDay)
+  // デフォルト23:59 (§FR-EVT-011-3)
+  dueAt.setHours(23, 59, 0, 0)
+  return dueAt
+}
+
+/** イベント開催日変更時に全タスクの締め切りを再計算 */
+export function recalculateDueDates(
+  tasks: { id: string; relativeDay: number | null }[],
+  newEventDate: Date | string,
+): { id: string; dueAt: Date }[] {
+  return tasks
+    .filter(t => t.relativeDay !== null)
+    .map(t => ({
+      id: t.id,
+      dueAt: calculateDueAt(newEventDate, t.relativeDay as number),
+    }))
+}

--- a/tests/unit/tasks/task-helpers.test.ts
+++ b/tests/unit/tasks/task-helpers.test.ts
@@ -1,0 +1,276 @@
+// EVT-010-014 タスクヘルパー ユニットテスト
+// 仕様書: docs/design/features/project/EVT-010-014_master-schedule.md
+// Note: Vue composable 依存を避けるため、ヘルパー関数をローカルに再定義してテスト
+import { describe, it, expect } from 'vitest'
+
+// ──────────────────────────────────────
+// ローカル再定義（composables/useTasks.ts と同等ロジック）
+// ──────────────────────────────────────
+
+type TaskStatus = 'pending' | 'in_progress' | 'completed' | 'skipped'
+type TaskPriority = 'high' | 'medium' | 'low'
+
+interface TaskSummary {
+  total: number
+  pending: number
+  inProgress: number
+  completed: number
+  skipped: number
+  overdue: number
+}
+
+const TASK_STATUS_LABELS: Record<TaskStatus, string> = {
+  pending: '未着手',
+  in_progress: '進行中',
+  completed: '完了',
+  skipped: 'スキップ',
+}
+
+const TASK_STATUS_COLORS: Record<TaskStatus, string> = {
+  pending: 'neutral',
+  in_progress: 'info',
+  completed: 'success',
+  skipped: 'warning',
+}
+
+const TASK_PRIORITY_LABELS: Record<TaskPriority, string> = {
+  high: '高',
+  medium: '中',
+  low: '低',
+}
+
+const TASK_PRIORITY_COLORS: Record<TaskPriority, string> = {
+  high: 'error',
+  medium: 'warning',
+  low: 'neutral',
+}
+
+const TASK_ROLE_LABELS: Record<string, string> = {
+  organizer: '主催者',
+  venue: '会場担当',
+  streaming: '配信担当',
+  event_planner: '企画代行',
+  speaker: '登壇者',
+  vendor: '業者',
+}
+
+function getTaskStatusLabel(status: TaskStatus): string {
+  return TASK_STATUS_LABELS[status] ?? status
+}
+
+function getTaskStatusColor(status: TaskStatus): string {
+  return TASK_STATUS_COLORS[status] ?? 'neutral'
+}
+
+function getTaskPriorityLabel(priority: TaskPriority): string {
+  return TASK_PRIORITY_LABELS[priority] ?? priority
+}
+
+function getTaskPriorityColor(priority: TaskPriority): string {
+  return TASK_PRIORITY_COLORS[priority] ?? 'neutral'
+}
+
+function getTaskRoleLabel(role: string | null): string {
+  if (!role) return '未割当'
+  return TASK_ROLE_LABELS[role] ?? role
+}
+
+function calculateProgress(summary: TaskSummary): number {
+  if (summary.total === 0) return 0
+  return Math.round(((summary.completed + summary.skipped) / summary.total) * 100)
+}
+
+function formatRelativeDay(day: number | null): string {
+  if (day === null) return '手動設定'
+  if (day === 0) return 'D-Day'
+  if (day < 0) return `D${day}`
+  return `D+${day}`
+}
+
+// ──────────────────────────────────────
+// テスト
+// ──────────────────────────────────────
+
+describe('getTaskStatusLabel', () => {
+  it('pending → 未着手', () => {
+    expect(getTaskStatusLabel('pending')).toBe('未着手')
+  })
+
+  it('in_progress → 進行中', () => {
+    expect(getTaskStatusLabel('in_progress')).toBe('進行中')
+  })
+
+  it('completed → 完了', () => {
+    expect(getTaskStatusLabel('completed')).toBe('完了')
+  })
+
+  it('skipped → スキップ', () => {
+    expect(getTaskStatusLabel('skipped')).toBe('スキップ')
+  })
+
+  it('不明な値はそのまま返す', () => {
+    expect(getTaskStatusLabel('unknown' as TaskStatus)).toBe('unknown')
+  })
+})
+
+describe('getTaskStatusColor', () => {
+  it('pending → neutral', () => {
+    expect(getTaskStatusColor('pending')).toBe('neutral')
+  })
+
+  it('in_progress → info', () => {
+    expect(getTaskStatusColor('in_progress')).toBe('info')
+  })
+
+  it('completed → success', () => {
+    expect(getTaskStatusColor('completed')).toBe('success')
+  })
+
+  it('skipped → warning', () => {
+    expect(getTaskStatusColor('skipped')).toBe('warning')
+  })
+
+  it('不明な値は neutral を返す', () => {
+    expect(getTaskStatusColor('unknown' as TaskStatus)).toBe('neutral')
+  })
+})
+
+describe('getTaskPriorityLabel', () => {
+  it('high → 高', () => {
+    expect(getTaskPriorityLabel('high')).toBe('高')
+  })
+
+  it('medium → 中', () => {
+    expect(getTaskPriorityLabel('medium')).toBe('中')
+  })
+
+  it('low → 低', () => {
+    expect(getTaskPriorityLabel('low')).toBe('低')
+  })
+
+  it('不明な値はそのまま返す', () => {
+    expect(getTaskPriorityLabel('critical' as TaskPriority)).toBe('critical')
+  })
+})
+
+describe('getTaskPriorityColor', () => {
+  it('high → error', () => {
+    expect(getTaskPriorityColor('high')).toBe('error')
+  })
+
+  it('medium → warning', () => {
+    expect(getTaskPriorityColor('medium')).toBe('warning')
+  })
+
+  it('low → neutral', () => {
+    expect(getTaskPriorityColor('low')).toBe('neutral')
+  })
+
+  it('不明な値は neutral を返す', () => {
+    expect(getTaskPriorityColor('critical' as TaskPriority)).toBe('neutral')
+  })
+})
+
+describe('getTaskRoleLabel', () => {
+  it('organizer → 主催者', () => {
+    expect(getTaskRoleLabel('organizer')).toBe('主催者')
+  })
+
+  it('venue → 会場担当', () => {
+    expect(getTaskRoleLabel('venue')).toBe('会場担当')
+  })
+
+  it('streaming → 配信担当', () => {
+    expect(getTaskRoleLabel('streaming')).toBe('配信担当')
+  })
+
+  it('event_planner → 企画代行', () => {
+    expect(getTaskRoleLabel('event_planner')).toBe('企画代行')
+  })
+
+  it('speaker → 登壇者', () => {
+    expect(getTaskRoleLabel('speaker')).toBe('登壇者')
+  })
+
+  it('vendor → 業者', () => {
+    expect(getTaskRoleLabel('vendor')).toBe('業者')
+  })
+
+  it('null → 未割当', () => {
+    expect(getTaskRoleLabel(null)).toBe('未割当')
+  })
+
+  it('不明なロールはそのまま返す', () => {
+    expect(getTaskRoleLabel('custom_role')).toBe('custom_role')
+  })
+})
+
+describe('calculateProgress', () => {
+  it('タスク0件は0%', () => {
+    const summary: TaskSummary = { total: 0, pending: 0, inProgress: 0, completed: 0, skipped: 0, overdue: 0 }
+    expect(calculateProgress(summary)).toBe(0)
+  })
+
+  it('全完了は100%', () => {
+    const summary: TaskSummary = { total: 10, pending: 0, inProgress: 0, completed: 10, skipped: 0, overdue: 0 }
+    expect(calculateProgress(summary)).toBe(100)
+  })
+
+  it('全スキップも100%', () => {
+    const summary: TaskSummary = { total: 5, pending: 0, inProgress: 0, completed: 0, skipped: 5, overdue: 0 }
+    expect(calculateProgress(summary)).toBe(100)
+  })
+
+  it('完了+スキップの合計で計算', () => {
+    const summary: TaskSummary = { total: 10, pending: 3, inProgress: 2, completed: 3, skipped: 2, overdue: 1 }
+    expect(calculateProgress(summary)).toBe(50) // (3+2)/10 = 50%
+  })
+
+  it('端数は四捨五入', () => {
+    const summary: TaskSummary = { total: 3, pending: 1, inProgress: 1, completed: 1, skipped: 0, overdue: 0 }
+    expect(calculateProgress(summary)).toBe(33) // 1/3 = 33.3... → 33
+  })
+
+  it('全未着手は0%', () => {
+    const summary: TaskSummary = { total: 10, pending: 10, inProgress: 0, completed: 0, skipped: 0, overdue: 0 }
+    expect(calculateProgress(summary)).toBe(0)
+  })
+})
+
+describe('formatRelativeDay', () => {
+  it('null → 手動設定', () => {
+    expect(formatRelativeDay(null)).toBe('手動設定')
+  })
+
+  it('0 → D-Day', () => {
+    expect(formatRelativeDay(0)).toBe('D-Day')
+  })
+
+  it('-7 → D-7', () => {
+    expect(formatRelativeDay(-7)).toBe('D-7')
+  })
+
+  it('-30 → D-30', () => {
+    expect(formatRelativeDay(-30)).toBe('D-30')
+  })
+
+  it('1 → D+1', () => {
+    expect(formatRelativeDay(1)).toBe('D+1')
+  })
+
+  it('14 → D+14', () => {
+    expect(formatRelativeDay(14)).toBe('D+14')
+  })
+
+  it('-1 → D-1', () => {
+    expect(formatRelativeDay(-1)).toBe('D-1')
+  })
+
+  it('-365 → D-365', () => {
+    expect(formatRelativeDay(-365)).toBe('D-365')
+  })
+
+  it('365 → D+365', () => {
+    expect(formatRelativeDay(365)).toBe('D+365')
+  })
+})

--- a/tests/unit/tasks/task-validation.test.ts
+++ b/tests/unit/tasks/task-validation.test.ts
@@ -1,0 +1,611 @@
+// EVT-010-014 タスクバリデーション ユニットテスト
+// 仕様書: docs/design/features/project/EVT-010-014_master-schedule.md §3-F
+import { describe, it, expect } from 'vitest'
+import {
+  createTaskSchema,
+  updateTaskSchema,
+  generateTasksSchema,
+  createTaskTemplateSchema,
+  updateTaskTemplateSchema,
+  TASK_STATUSES,
+  TASK_PRIORITIES,
+  TASK_ROLES,
+  MAX_TASKS_PER_EVENT,
+  RELATIVE_DAY_MIN,
+  RELATIVE_DAY_MAX,
+  SORT_ORDER_MIN,
+  SORT_ORDER_MAX,
+  isValidTaskStatusTransition,
+  TASK_STATUS_TRANSITIONS,
+  calculateDueAt,
+  recalculateDueDates,
+} from '~/server/utils/task-validation'
+
+// ──────────────────────────────────────
+// 定数テスト
+// ──────────────────────────────────────
+describe('定数定義', () => {
+  it('TASK_STATUSES は4種類', () => {
+    expect(TASK_STATUSES).toEqual(['pending', 'in_progress', 'completed', 'skipped'])
+  })
+
+  it('TASK_PRIORITIES は3種類', () => {
+    expect(TASK_PRIORITIES).toEqual(['high', 'medium', 'low'])
+  })
+
+  it('TASK_ROLES は6種類', () => {
+    expect(TASK_ROLES).toEqual(['organizer', 'venue', 'streaming', 'event_planner', 'speaker', 'vendor'])
+  })
+
+  it('MAX_TASKS_PER_EVENT は200', () => {
+    expect(MAX_TASKS_PER_EVENT).toBe(200)
+  })
+
+  it('RELATIVE_DAY の範囲は -365 〜 365', () => {
+    expect(RELATIVE_DAY_MIN).toBe(-365)
+    expect(RELATIVE_DAY_MAX).toBe(365)
+  })
+
+  it('SORT_ORDER の範囲は 0 〜 9999', () => {
+    expect(SORT_ORDER_MIN).toBe(0)
+    expect(SORT_ORDER_MAX).toBe(9999)
+  })
+})
+
+// ──────────────────────────────────────
+// createTaskSchema テスト
+// ──────────────────────────────────────
+describe('createTaskSchema', () => {
+  const validPayload = {
+    title: '企画書作成',
+    description: '詳細な説明',
+    assigned_role: 'organizer',
+    priority: 'high' as const,
+    relative_day: -7,
+    sort_order: 1,
+  }
+
+  describe('正常系', () => {
+    it('全フィールド指定で成功', () => {
+      const result = createTaskSchema.safeParse(validPayload)
+      expect(result.success).toBe(true)
+    })
+
+    it('必須フィールド（title）のみで成功', () => {
+      const result = createTaskSchema.safeParse({ title: 'テスト' })
+      expect(result.success).toBe(true)
+    })
+
+    it('priority のデフォルトは medium', () => {
+      const result = createTaskSchema.safeParse({ title: 'テスト' })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.priority).toBe('medium')
+      }
+    })
+
+    it('due_at を直接指定できる', () => {
+      const result = createTaskSchema.safeParse({
+        title: 'テスト',
+        due_at: '2026-03-01T23:59:00.000Z',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('relative_day のみ指定で成功', () => {
+      const result = createTaskSchema.safeParse({
+        title: 'テスト',
+        relative_day: -30,
+      })
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('§3-F 境界値: title', () => {
+    it('1文字で成功', () => {
+      const result = createTaskSchema.safeParse({ title: 'A' })
+      expect(result.success).toBe(true)
+    })
+
+    it('200文字で成功', () => {
+      const result = createTaskSchema.safeParse({ title: 'あ'.repeat(200) })
+      expect(result.success).toBe(true)
+    })
+
+    it('空文字でエラー', () => {
+      const result = createTaskSchema.safeParse({ title: '' })
+      expect(result.success).toBe(false)
+    })
+
+    it('201文字でエラー', () => {
+      const result = createTaskSchema.safeParse({ title: 'あ'.repeat(201) })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('§3-F 境界値: description', () => {
+    it('2000文字で成功', () => {
+      const result = createTaskSchema.safeParse({ title: 'テスト', description: 'a'.repeat(2000) })
+      expect(result.success).toBe(true)
+    })
+
+    it('2001文字でエラー', () => {
+      const result = createTaskSchema.safeParse({ title: 'テスト', description: 'a'.repeat(2001) })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('§3-F 境界値: relative_day', () => {
+    it('-365 で成功', () => {
+      const result = createTaskSchema.safeParse({ title: 'テスト', relative_day: -365 })
+      expect(result.success).toBe(true)
+    })
+
+    it('365 で成功', () => {
+      const result = createTaskSchema.safeParse({ title: 'テスト', relative_day: 365 })
+      expect(result.success).toBe(true)
+    })
+
+    it('0 で成功（D-Day）', () => {
+      const result = createTaskSchema.safeParse({ title: 'テスト', relative_day: 0 })
+      expect(result.success).toBe(true)
+    })
+
+    it('-366 でエラー', () => {
+      const result = createTaskSchema.safeParse({ title: 'テスト', relative_day: -366 })
+      expect(result.success).toBe(false)
+    })
+
+    it('366 でエラー', () => {
+      const result = createTaskSchema.safeParse({ title: 'テスト', relative_day: 366 })
+      expect(result.success).toBe(false)
+    })
+
+    it('小数でエラー', () => {
+      const result = createTaskSchema.safeParse({ title: 'テスト', relative_day: 1.5 })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('§3-F 境界値: sort_order', () => {
+    it('0 で成功', () => {
+      const result = createTaskSchema.safeParse({ title: 'テスト', sort_order: 0 })
+      expect(result.success).toBe(true)
+    })
+
+    it('9999 で成功', () => {
+      const result = createTaskSchema.safeParse({ title: 'テスト', sort_order: 9999 })
+      expect(result.success).toBe(true)
+    })
+
+    it('-1 でエラー', () => {
+      const result = createTaskSchema.safeParse({ title: 'テスト', sort_order: -1 })
+      expect(result.success).toBe(false)
+    })
+
+    it('10000 でエラー', () => {
+      const result = createTaskSchema.safeParse({ title: 'テスト', sort_order: 10000 })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('§3-F 境界値: priority', () => {
+    it.each(TASK_PRIORITIES)('priority=%s で成功', (p) => {
+      const result = createTaskSchema.safeParse({ title: 'テスト', priority: p })
+      expect(result.success).toBe(true)
+    })
+
+    it('不正な priority でエラー', () => {
+      const result = createTaskSchema.safeParse({ title: 'テスト', priority: 'critical' })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('relative_day と due_at の排他制約', () => {
+    it('両方指定でエラー', () => {
+      const result = createTaskSchema.safeParse({
+        title: 'テスト',
+        relative_day: -7,
+        due_at: '2026-03-01T23:59:00.000Z',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        const messages = result.error.issues.map(i => i.message)
+        expect(messages).toContain('relative_day と due_at は同時に指定できません')
+      }
+    })
+
+    it('どちらも未指定で成功', () => {
+      const result = createTaskSchema.safeParse({ title: 'テスト' })
+      expect(result.success).toBe(true)
+    })
+  })
+})
+
+// ──────────────────────────────────────
+// updateTaskSchema テスト
+// ──────────────────────────────────────
+describe('updateTaskSchema', () => {
+  it('空オブジェクトで成功（全フィールドオプショナル）', () => {
+    const result = updateTaskSchema.safeParse({})
+    expect(result.success).toBe(true)
+  })
+
+  it('title のみ更新で成功', () => {
+    const result = updateTaskSchema.safeParse({ title: '更新後タイトル' })
+    expect(result.success).toBe(true)
+  })
+
+  it('status のみ更新で成功', () => {
+    const result = updateTaskSchema.safeParse({ status: 'in_progress' })
+    expect(result.success).toBe(true)
+  })
+
+  it('不正な status でエラー', () => {
+    const result = updateTaskSchema.safeParse({ status: 'done' })
+    expect(result.success).toBe(false)
+  })
+
+  it('title 空文字でエラー（min(1)）', () => {
+    const result = updateTaskSchema.safeParse({ title: '' })
+    expect(result.success).toBe(false)
+  })
+})
+
+// ──────────────────────────────────────
+// generateTasksSchema テスト
+// ──────────────────────────────────────
+describe('generateTasksSchema', () => {
+  it('空オブジェクトで成功（デフォルト値適用）', () => {
+    const result = generateTasksSchema.safeParse({})
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.use_template).toBe(true)
+      expect(result.data.overwrite).toBe(false)
+    }
+  })
+
+  it('overwrite=true で成功', () => {
+    const result = generateTasksSchema.safeParse({ overwrite: true })
+    expect(result.success).toBe(true)
+  })
+
+  it('custom_prompt を指定できる', () => {
+    const result = generateTasksSchema.safeParse({ custom_prompt: 'カスタムプロンプト' })
+    expect(result.success).toBe(true)
+  })
+
+  it('custom_prompt が2001文字でエラー', () => {
+    const result = generateTasksSchema.safeParse({ custom_prompt: 'a'.repeat(2001) })
+    expect(result.success).toBe(false)
+  })
+})
+
+// ──────────────────────────────────────
+// createTaskTemplateSchema テスト
+// ──────────────────────────────────────
+describe('createTaskTemplateSchema', () => {
+  const validPayload = {
+    event_type: 'seminar',
+    title: '企画書作成',
+    assigned_role: 'organizer',
+    relative_day: -30,
+  }
+
+  describe('正常系', () => {
+    it('必須フィールドで成功', () => {
+      const result = createTaskTemplateSchema.safeParse(validPayload)
+      expect(result.success).toBe(true)
+    })
+
+    it('全フィールド指定で成功', () => {
+      const result = createTaskTemplateSchema.safeParse({
+        ...validPayload,
+        description: 'テンプレート説明',
+        priority: 'high',
+        sort_order: 10,
+        is_active: false,
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('priority デフォルトは medium', () => {
+      const result = createTaskTemplateSchema.safeParse(validPayload)
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.priority).toBe('medium')
+      }
+    })
+
+    it('sort_order デフォルトは 0', () => {
+      const result = createTaskTemplateSchema.safeParse(validPayload)
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.sort_order).toBe(0)
+      }
+    })
+
+    it('is_active デフォルトは true', () => {
+      const result = createTaskTemplateSchema.safeParse(validPayload)
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.is_active).toBe(true)
+      }
+    })
+  })
+
+  describe('§3-F 境界値: event_type', () => {
+    it('空文字でエラー', () => {
+      const result = createTaskTemplateSchema.safeParse({ ...validPayload, event_type: '' })
+      expect(result.success).toBe(false)
+    })
+
+    it('50文字で成功', () => {
+      const result = createTaskTemplateSchema.safeParse({ ...validPayload, event_type: 'a'.repeat(50) })
+      expect(result.success).toBe(true)
+    })
+
+    it('51文字でエラー', () => {
+      const result = createTaskTemplateSchema.safeParse({ ...validPayload, event_type: 'a'.repeat(51) })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('§3-F 境界値: title', () => {
+    it('空文字でエラー', () => {
+      const result = createTaskTemplateSchema.safeParse({ ...validPayload, title: '' })
+      expect(result.success).toBe(false)
+    })
+
+    it('200文字で成功', () => {
+      const result = createTaskTemplateSchema.safeParse({ ...validPayload, title: 'テ'.repeat(200) })
+      expect(result.success).toBe(true)
+    })
+
+    it('201文字でエラー', () => {
+      const result = createTaskTemplateSchema.safeParse({ ...validPayload, title: 'テ'.repeat(201) })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('§3-F 境界値: assigned_role', () => {
+    it('空文字でエラー', () => {
+      const result = createTaskTemplateSchema.safeParse({ ...validPayload, assigned_role: '' })
+      expect(result.success).toBe(false)
+    })
+
+    it('50文字で成功', () => {
+      const result = createTaskTemplateSchema.safeParse({ ...validPayload, assigned_role: 'r'.repeat(50) })
+      expect(result.success).toBe(true)
+    })
+
+    it('51文字でエラー', () => {
+      const result = createTaskTemplateSchema.safeParse({ ...validPayload, assigned_role: 'r'.repeat(51) })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('必須フィールド欠落', () => {
+    it('event_type 欠落でエラー', () => {
+      const { event_type, ...rest } = validPayload
+      const result = createTaskTemplateSchema.safeParse(rest)
+      expect(result.success).toBe(false)
+    })
+
+    it('title 欠落でエラー', () => {
+      const { title, ...rest } = validPayload
+      const result = createTaskTemplateSchema.safeParse(rest)
+      expect(result.success).toBe(false)
+    })
+
+    it('assigned_role 欠落でエラー', () => {
+      const { assigned_role, ...rest } = validPayload
+      const result = createTaskTemplateSchema.safeParse(rest)
+      expect(result.success).toBe(false)
+    })
+
+    it('relative_day 欠落でエラー', () => {
+      const { relative_day, ...rest } = validPayload
+      const result = createTaskTemplateSchema.safeParse(rest)
+      expect(result.success).toBe(false)
+    })
+  })
+})
+
+// ──────────────────────────────────────
+// updateTaskTemplateSchema テスト
+// ──────────────────────────────────────
+describe('updateTaskTemplateSchema', () => {
+  it('空オブジェクトで成功（全フィールドオプショナル）', () => {
+    const result = updateTaskTemplateSchema.safeParse({})
+    expect(result.success).toBe(true)
+  })
+
+  it('title のみ更新で成功', () => {
+    const result = updateTaskTemplateSchema.safeParse({ title: '更新テンプレート' })
+    expect(result.success).toBe(true)
+  })
+
+  it('is_active を false に更新で成功', () => {
+    const result = updateTaskTemplateSchema.safeParse({ is_active: false })
+    expect(result.success).toBe(true)
+  })
+})
+
+// ──────────────────────────────────────
+// ステータス遷移テスト
+// ──────────────────────────────────────
+describe('isValidTaskStatusTransition', () => {
+  describe('同じ状態への遷移はOK', () => {
+    it.each(TASK_STATUSES)('%s → %s は有効', (status) => {
+      expect(isValidTaskStatusTransition(status, status)).toBe(true)
+    })
+  })
+
+  describe('pending からの遷移', () => {
+    it('pending → in_progress は有効', () => {
+      expect(isValidTaskStatusTransition('pending', 'in_progress')).toBe(true)
+    })
+    it('pending → skipped は有効', () => {
+      expect(isValidTaskStatusTransition('pending', 'skipped')).toBe(true)
+    })
+    it('pending → completed は無効', () => {
+      expect(isValidTaskStatusTransition('pending', 'completed')).toBe(false)
+    })
+  })
+
+  describe('in_progress からの遷移', () => {
+    it('in_progress → completed は有効', () => {
+      expect(isValidTaskStatusTransition('in_progress', 'completed')).toBe(true)
+    })
+    it('in_progress → skipped は有効', () => {
+      expect(isValidTaskStatusTransition('in_progress', 'skipped')).toBe(true)
+    })
+    it('in_progress → pending は有効（差し戻し）', () => {
+      expect(isValidTaskStatusTransition('in_progress', 'pending')).toBe(true)
+    })
+  })
+
+  describe('completed からの遷移', () => {
+    it('completed → pending は有効（再オープン）', () => {
+      expect(isValidTaskStatusTransition('completed', 'pending')).toBe(true)
+    })
+    it('completed → in_progress は無効', () => {
+      expect(isValidTaskStatusTransition('completed', 'in_progress')).toBe(false)
+    })
+    it('completed → skipped は無効', () => {
+      expect(isValidTaskStatusTransition('completed', 'skipped')).toBe(false)
+    })
+  })
+
+  describe('skipped からの遷移', () => {
+    it('skipped → pending は有効（再オープン）', () => {
+      expect(isValidTaskStatusTransition('skipped', 'pending')).toBe(true)
+    })
+    it('skipped → in_progress は無効', () => {
+      expect(isValidTaskStatusTransition('skipped', 'in_progress')).toBe(false)
+    })
+    it('skipped → completed は無効', () => {
+      expect(isValidTaskStatusTransition('skipped', 'completed')).toBe(false)
+    })
+  })
+
+  describe('TASK_STATUS_TRANSITIONS マップの網羅性', () => {
+    it('全ステータスがキーに存在する', () => {
+      for (const status of TASK_STATUSES) {
+        expect(TASK_STATUS_TRANSITIONS).toHaveProperty(status)
+      }
+    })
+
+    it('遷移先は全てTASK_STATUSESに含まれる', () => {
+      for (const [, targets] of Object.entries(TASK_STATUS_TRANSITIONS)) {
+        for (const target of targets) {
+          expect(TASK_STATUSES).toContain(target)
+        }
+      }
+    })
+  })
+})
+
+// ──────────────────────────────────────
+// 締め切り計算テスト
+// ──────────────────────────────────────
+describe('calculateDueAt', () => {
+  const eventDate = '2026-04-01T10:00:00.000Z'
+
+  it('relative_day=0 は D-Day (23:59)', () => {
+    const result = calculateDueAt(eventDate, 0)
+    expect(result.getFullYear()).toBe(2026)
+    expect(result.getMonth()).toBe(3) // April = 3
+    expect(result.getDate()).toBe(1)
+    expect(result.getHours()).toBe(23)
+    expect(result.getMinutes()).toBe(59)
+  })
+
+  it('relative_day=-7 は7日前', () => {
+    const result = calculateDueAt(eventDate, -7)
+    expect(result.getDate()).toBe(25) // April 1 - 7 = March 25
+    expect(result.getMonth()).toBe(2) // March = 2
+  })
+
+  it('relative_day=1 は1日後', () => {
+    const result = calculateDueAt(eventDate, 1)
+    expect(result.getDate()).toBe(2)
+    expect(result.getMonth()).toBe(3) // April
+  })
+
+  it('relative_day=-30 は30日前', () => {
+    const result = calculateDueAt(eventDate, -30)
+    expect(result.getMonth()).toBe(2) // March
+    expect(result.getDate()).toBe(2) // March 2
+  })
+
+  it('Date オブジェクトも受け付ける', () => {
+    const dateObj = new Date('2026-04-01T10:00:00.000Z')
+    const result = calculateDueAt(dateObj, -1)
+    expect(result.getDate()).toBe(31)
+    expect(result.getMonth()).toBe(2) // March
+  })
+
+  it('時刻は 23:59:00.000 に設定される', () => {
+    const result = calculateDueAt(eventDate, 0)
+    expect(result.getHours()).toBe(23)
+    expect(result.getMinutes()).toBe(59)
+    expect(result.getSeconds()).toBe(0)
+    expect(result.getMilliseconds()).toBe(0)
+  })
+})
+
+// ──────────────────────────────────────
+// 再計算テスト
+// ──────────────────────────────────────
+describe('recalculateDueDates', () => {
+  const newEventDate = '2026-05-01T10:00:00.000Z'
+
+  it('relativeDay が null のタスクはスキップされる', () => {
+    const tasks = [
+      { id: 't1', relativeDay: -7 },
+      { id: 't2', relativeDay: null },
+      { id: 't3', relativeDay: 0 },
+    ]
+    const result = recalculateDueDates(tasks, newEventDate)
+    expect(result).toHaveLength(2)
+    expect(result.map(r => r.id)).toEqual(['t1', 't3'])
+  })
+
+  it('各タスクの dueAt が正しく再計算される', () => {
+    const tasks = [
+      { id: 't1', relativeDay: -30 },
+      { id: 't2', relativeDay: 0 },
+      { id: 't3', relativeDay: 5 },
+    ]
+    const result = recalculateDueDates(tasks, newEventDate)
+    expect(result).toHaveLength(3)
+
+    // t1: May 1 - 30 = April 1
+    expect(result[0].dueAt.getMonth()).toBe(3) // April
+    expect(result[0].dueAt.getDate()).toBe(1)
+
+    // t2: May 1
+    expect(result[1].dueAt.getMonth()).toBe(4) // May
+    expect(result[1].dueAt.getDate()).toBe(1)
+
+    // t3: May 1 + 5 = May 6
+    expect(result[2].dueAt.getMonth()).toBe(4)
+    expect(result[2].dueAt.getDate()).toBe(6)
+  })
+
+  it('空配列は空配列を返す', () => {
+    const result = recalculateDueDates([], newEventDate)
+    expect(result).toEqual([])
+  })
+
+  it('全て relativeDay=null なら空配列', () => {
+    const tasks = [
+      { id: 't1', relativeDay: null },
+      { id: 't2', relativeDay: null },
+    ]
+    const result = recalculateDueDates(tasks, newEventDate)
+    expect(result).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary
- タスクCRUD API 6本 (一覧/作成/更新/完了/削除 + テンプレート自動展開)
- テンプレートCRUD API 4本 (一覧/作成/更新/削除)
- Zodバリデーション (§3-F境界値: title 1-200, description 2000, relative_day ±365, sort_order 0-9999)
- ステータス遷移チェック (pending→in_progress/skipped, in_progress→completed/skipped/pending, completed/skipped→pending)
- 締め切り自動計算 (相対日 → 絶対日 23:59)
- useTasks composable (CRUD + フィルタ + 自動生成)
- タスクボードUI (進捗サマリー/フィルタ/一覧/作成・削除モーダル)
- ユニットテスト 132件 (バリデーション91件 + ヘルパー41件)

## Test plan
- [x] バリデーションテスト 91件 パス
- [x] ヘルパーテスト 41件 パス
- [x] 全テストスイート 527件 パス
- [x] ESLint エラーなし
- [ ] 結合テスト: タスク作成→更新→完了フロー
- [ ] E2E: タスクボード画面操作

🤖 Generated with [Claude Code](https://claude.com/claude-code)